### PR TITLE
feat: add CGO growth agent

### DIFF
--- a/api/routes/cgo.py
+++ b/api/routes/cgo.py
@@ -1,0 +1,156 @@
+"""
+CGO routes — growth analysis and new revenue-stream billing.
+"""
+
+import logging
+import os
+from typing import Any, Dict
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query
+from pydantic import BaseModel
+
+from api.middleware import get_current_user_id
+from ora.agents.cgo_agent import run_cgo_growth_analysis
+from ora.payments.growth_billing import (
+    API_ACCESS_PLANS,
+    ORA_SESSION_TYPES,
+    GrowthBillingError,
+    create_api_access_checkout,
+    create_corporate_plan_checkout,
+    create_ora_session_payment,
+)
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/cgo", tags=["cgo"])
+
+ADMIN_TOKEN = os.getenv("ADMIN_TOKEN", os.getenv("ADMIN_SECRET", "connectome-admin-secret"))
+
+
+class OraSessionCheckoutRequest(BaseModel):
+    session_type: str = "clarity"
+
+
+class CorporateCheckoutRequest(BaseModel):
+    org_name: str = "Connectome Corporate Partner"
+    seats: int = 10
+    contact_email: str = "growth@connectome.app"
+
+
+def _require_admin(x_admin_token: str = Header(default="")) -> None:
+    if x_admin_token != ADMIN_TOKEN:
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+
+def _translate_billing_error(exc: Exception) -> HTTPException:
+    if isinstance(exc, ValueError):
+        return HTTPException(status_code=400, detail=str(exc))
+    if isinstance(exc, GrowthBillingError):
+        return HTTPException(status_code=exc.status, detail={"message": str(exc), "code": exc.code})
+    logger.exception("Unexpected CGO billing error: %s", exc)
+    return HTTPException(status_code=500, detail="Unable to create checkout session")
+
+
+@router.get("/growth-report")
+async def growth_report(x_admin_token: str = Header(default="")) -> Dict[str, Any]:
+    """Run the CGO analysis and return a structured growth report. Admin-only."""
+    _require_admin(x_admin_token)
+    return await run_cgo_growth_analysis()
+
+
+@router.get("/billing/api-access")
+async def billing_api_access(
+    plan: str = Query("developer", description="developer | scale"),
+    user_id: str = Depends(get_current_user_id),
+) -> Dict[str, Any]:
+    """Create a Stripe Checkout Session for the developer API access tier."""
+    try:
+        checkout = await create_api_access_checkout(user_id=user_id, plan=plan)
+        return {
+            "stream": "developer_api",
+            "plan": plan,
+            "available_plans": API_ACCESS_PLANS,
+            **checkout,
+        }
+    except Exception as exc:
+        raise _translate_billing_error(exc)
+
+
+@router.get("/billing/corporate")
+async def billing_corporate(
+    org_name: str = Query("Connectome Corporate Partner"),
+    seats: int = Query(10, ge=10),
+    contact_email: str = Query("growth@connectome.app"),
+    x_admin_token: str = Header(default=""),
+) -> Dict[str, Any]:
+    """
+    Return corporate wellness plan info and create a Stripe Checkout Session.
+    Admin-only because this is a negotiated B2B stream.
+    """
+    _require_admin(x_admin_token)
+    try:
+        checkout = await create_corporate_plan_checkout(
+            org_name=org_name,
+            seats=seats,
+            contact_email=str(contact_email),
+        )
+        return {
+            "stream": "corporate_wellness",
+            "plan": {
+                "unit_amount_cents_per_seat": 800,
+                "currency": "usd",
+                "interval": "month",
+                "minimum_seats": 10,
+                "requested_seats": max(seats, 10),
+                "monthly_total_cents": max(seats, 10) * 800,
+            },
+            **checkout,
+        }
+    except Exception as exc:
+        raise _translate_billing_error(exc)
+
+
+@router.post("/billing/corporate")
+async def billing_corporate_post(
+    body: CorporateCheckoutRequest,
+    x_admin_token: str = Header(default=""),
+) -> Dict[str, Any]:
+    """POST variant for corporate checkout creation with a JSON body."""
+    _require_admin(x_admin_token)
+    try:
+        checkout = await create_corporate_plan_checkout(
+            org_name=body.org_name,
+            seats=body.seats,
+            contact_email=str(body.contact_email),
+        )
+        return {
+            "stream": "corporate_wellness",
+            "plan": {
+                "unit_amount_cents_per_seat": 800,
+                "currency": "usd",
+                "interval": "month",
+                "minimum_seats": 10,
+                "requested_seats": max(body.seats, 10),
+                "monthly_total_cents": max(body.seats, 10) * 800,
+            },
+            **checkout,
+        }
+    except Exception as exc:
+        raise _translate_billing_error(exc)
+
+
+@router.post("/billing/ora-session")
+async def billing_ora_session(
+    body: OraSessionCheckoutRequest,
+    user_id: str = Depends(get_current_user_id),
+) -> Dict[str, Any]:
+    """Create a one-off Stripe Checkout Session for a premium Ora Session."""
+    try:
+        checkout = await create_ora_session_payment(user_id=user_id, session_type=body.session_type)
+        return {
+            "stream": "ora_session",
+            "session_type": body.session_type,
+            "available_session_types": ORA_SESSION_TYPES,
+            **checkout,
+        }
+    except Exception as exc:
+        raise _translate_billing_error(exc)

--- a/main.py
+++ b/main.py
@@ -75,6 +75,13 @@ except Exception as _executive_err:
     executive_routes = None
     _executive_available = False
     logging.warning(f"Executive routes unavailable: {_executive_err}")
+try:
+    from api.routes import cgo as cgo_routes
+    _cgo_available = True
+except Exception as _cgo_err:
+    cgo_routes = None
+    _cgo_available = False
+    logging.warning(f"CGO routes unavailable: {_cgo_err}")
 from core.notification_worker import start_notification_worker, stop_notification_worker
 
 # Configure logging
@@ -283,6 +290,8 @@ if _services_available and services_routes:
     app.include_router(services_routes.router)
 if _executive_available and executive_routes:
     app.include_router(executive_routes.router)
+if _cgo_available and cgo_routes:
+    app.include_router(cgo_routes.router)
 if _ioo_available and ioo_routes:
     app.include_router(ioo_routes.router)
 try:

--- a/ora/agents/cgo_agent.py
+++ b/ora/agents/cgo_agent.py
@@ -1,0 +1,337 @@
+"""
+CGO Agent — Chief Growth Officer for Connectome/Ora.
+
+Mandate: aggressively and creatively grow revenue while protecting the
+non-profit mission. The CGO never assumes a surface is impossible to monetize;
+it finds ethical, legally sound revenue architecture around genuine value.
+"""
+
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+import httpx
+
+from ora.agents.base_executive_agent import API_BASE, BaseExecutiveAgent
+from ora.payments.growth_billing import (
+    create_api_access_checkout,
+    create_corporate_plan_checkout,
+    create_ora_session_payment,
+)
+
+logger = logging.getLogger(__name__)
+
+ADMIN_TOKEN = os.getenv("ADMIN_TOKEN", os.getenv("ADMIN_SECRET", "connectome-admin-secret"))
+
+
+class CGOAgent(BaseExecutiveAgent):
+    """
+    Ora's Chief Growth Officer.
+
+    Thinks like a startup growth hacker plus a mission-driven social enterprise:
+    data-driven, commercial, fast-moving, and allergic to fake scarcity or
+    deceptive billing. Revenue exists to make the human-flourishing mission
+    durable.
+    """
+
+    name = "cgo"
+    display_name = "CGO Agent"
+
+    async def analyze(self) -> Dict[str, Any]:
+        now = datetime.now(timezone.utc)
+        metrics = await self._get_revenue_metrics()
+        research = {
+            "freemium_conversion": await self._research_freemium_conversion(metrics),
+            "grants": await self._research_grants(metrics),
+            "b2b_corporate_wellness": await self._research_corporate_wellness(metrics),
+            "api_access_monetization": await self._research_api_access(metrics),
+            "community_membership": await self._research_community_membership(metrics),
+            "ip_licensing_white_label": await self._research_ip_licensing(metrics),
+        }
+        streams = self._prioritize_revenue_streams(metrics, research)
+        activation = await self._activate_top_streams(streams)
+
+        report = {
+            "agent": self.name,
+            "analyzed_at": now.isoformat(),
+            "mandate": "Revenue serves the mission: fund Ora's non-profit AI OS for human flourishing.",
+            "metrics": metrics,
+            "research": research,
+            "prioritized_action_plan": self._build_action_plan(streams, metrics),
+            "activated_revenue_streams": activation,
+            "structured_growth_report": {
+                "stage": self._stage(metrics),
+                "top_3_revenue_streams": [s["name"] for s in streams[:3]],
+                "north_star": "First $1,000 MRR without compromising trust or mission alignment.",
+                "legal_guardrails": [
+                    "No deceptive billing or forced continuity.",
+                    "Clear cancellation path for every subscription.",
+                    "Revenue claims must be grounded in actual user value and consent.",
+                    "Grant and corporate messaging must preserve the non-profit mission.",
+                ],
+            },
+        }
+        return report
+
+    async def report(self) -> str:
+        data = await self.load_last_report("cgo_report.json") or await self.analyze()
+        metrics = data.get("metrics", {})
+        top = data.get("prioritized_action_plan", [])[:3]
+        actions = "\n".join(f"• {item.get('action', item)}" for item in top)
+        return (
+            f"📈 *CGO Report* — {data.get('analyzed_at', '')[:10]}\n"
+            f"Users: {metrics.get('total_users', 0)} | Paid: {metrics.get('paid_users', 0)} | "
+            f"Revenue: ${metrics.get('total_revenue_cents', 0) / 100:.2f}\n"
+            f"Stage: {data.get('structured_growth_report', {}).get('stage', 'unknown')}\n"
+            f"Top moves:\n{actions}"
+        )
+
+    async def recommend(self) -> List[str]:
+        data = await self.analyze()
+        return [item["action"] for item in data.get("prioritized_action_plan", [])]
+
+    async def act(self) -> Dict[str, Any]:
+        data = await self.analyze()
+        path = await self.save_report(data, "cgo_report.json")
+        summary = await self.report()
+        await self.set_redis_report(summary)
+        await self.teach_ora(
+            "CGO growth state: "
+            f"{data['metrics'].get('total_users', 0)} users, "
+            f"${data['metrics'].get('total_revenue_cents', 0) / 100:.2f} lifetime revenue, "
+            f"top streams={', '.join(data['structured_growth_report']['top_3_revenue_streams'])}.",
+            confidence=0.82,
+        )
+        return {
+            "agent": self.name,
+            "actions": [
+                f"Saved CGO report to {path}",
+                "Updated Redis executive summary",
+                "Taught Ora the current growth thesis",
+                "Prepared Stripe Checkout activation links for top revenue streams",
+            ],
+            "report": data,
+        }
+
+    async def _get_revenue_metrics(self) -> Dict[str, Any]:
+        metrics: Dict[str, Any] = {
+            "total_users": 17,
+            "active_today": 0,
+            "active_users_7d": 0,
+            "paid_users": 0,
+            "premium_users": 0,
+            "total_revenue_cents": 0,
+            "mrr_cents_est": 0,
+            "conversion_rate_pct": 0.0,
+            "source": "fallback_pre_revenue_context",
+        }
+
+        # Prefer the admin API because that is the source the dashboard already trusts.
+        try:
+            async with httpx.AsyncClient(timeout=20) as client:
+                resp = await client.get(
+                    f"{API_BASE}/api/admin/insights",
+                    headers={"X-Admin-Token": ADMIN_TOKEN},
+                )
+            if resp.status_code == 200:
+                data = resp.json()
+                metrics.update(
+                    total_users=int(data.get("total_users", 0) or 0),
+                    active_today=int(data.get("active_today", 0) or 0),
+                    premium_users=int(data.get("premium_users", 0) or 0),
+                    paid_users=int(data.get("premium_users", 0) or 0),
+                    total_revenue_cents=int(data.get("total_revenue_cents", 0) or 0),
+                    source="admin_api",
+                )
+        except Exception as exc:
+            logger.warning("CGO admin metrics fetch failed: %s", exc)
+
+        try:
+            async with httpx.AsyncClient(timeout=20) as client:
+                resp = await client.get(
+                    f"{API_BASE}/api/admin/growth-metrics",
+                    headers={"X-Admin-Token": ADMIN_TOKEN},
+                )
+            if resp.status_code == 200:
+                data = resp.json()
+                metrics["active_users_7d"] = int(data.get("active_users_7d", 0) or metrics["active_users_7d"])
+                metrics["new_users_7d"] = int(data.get("new_users_7d", 0) or 0)
+        except Exception as exc:
+            logger.debug("CGO growth metrics fetch failed: %s", exc)
+
+        if metrics["total_users"]:
+            metrics["conversion_rate_pct"] = round(metrics["paid_users"] / metrics["total_users"] * 100, 2)
+        metrics["mrr_cents_est"] = metrics["paid_users"] * 900
+        return metrics
+
+    async def _research_freemium_conversion(self, metrics: Dict[str, Any]) -> Dict[str, Any]:
+        active = metrics.get("active_users_7d") or metrics.get("active_today") or 0
+        paid = metrics.get("paid_users", 0)
+        return {
+            "opportunity": "High-engagement free users are the fastest path to first MRR.",
+            "signal": f"{active} recently active users, {paid} paid users.",
+            "next_steps": [
+                "Query free users with >5 goal/session events in 14 days.",
+                "Offer Explorer trial at the exact moment a user hits a limit or completes a meaningful goal.",
+                "Add mission-framed upgrade copy: pay to sustain Ora for everyone, not to unlock artificial scarcity.",
+            ],
+            "expected_impact": "2-5 paid users can validate willingness-to-pay before paid acquisition.",
+        }
+
+    async def _research_grants(self, metrics: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "targets": ["Wellcome Trust", "Google.org", "Mozilla Builders", "AI for Good", "social enterprise grants"],
+            "angle": "AI OS for mental clarity, fulfilment, personal agency, and public-good flourishing infrastructure.",
+            "next_steps": [
+                "Create a 2-page grant narrative with outcomes, safeguards, and evaluation metrics.",
+                "Package anonymised fulfilment-score deltas once product telemetry supports it.",
+                "Build a grant CRM with deadlines and fit score.",
+            ],
+            "expected_impact": "Non-dilutive runway; slower cycle but mission-aligned.",
+        }
+
+    async def _research_corporate_wellness(self, metrics: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "offer": "$8/seat/month, 10-seat minimum for workplace clarity and aligned-action support.",
+            "ideal_customers": ["remote startups", "creator teams", "mission-driven non-profits", "conscious business communities"],
+            "next_steps": [
+                "Create one landing page for teams: clarity, goals, reflection, and burnout prevention.",
+                "Offer a 30-day pilot to 3 founder-led teams.",
+                "Add team-level onboarding and lightweight admin export before scaling.",
+            ],
+            "expected_impact": "One 25-seat team at $8/seat/month creates $200 MRR immediately.",
+        }
+
+    async def _research_api_access(self, metrics: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "offer": "$29/month developer tier with 10k calls; $99/month scale tier with 100k calls.",
+            "buyers": ["indie hackers", "wellness apps", "coaches", "community platforms"],
+            "next_steps": [
+                "Expose a scoped API key flow and usage dashboard.",
+                "Publish docs for goal coaching, reflection prompts, and fulfilment insights endpoints.",
+                "Add metered overages only after clear usage notifications exist.",
+            ],
+            "expected_impact": "Fastest scalable stream once docs/key management exist.",
+        }
+
+    async def _research_community_membership(self, metrics: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "offer": "Founding Steward membership: monthly patronage, early roadmap voice, and public mission badge.",
+            "guardrail": "No pay-to-win governance; CP acceleration must be capped and transparent.",
+            "next_steps": [
+                "Survey community willingness-to-pay for founding membership.",
+                "Bundle office hours, behind-the-scenes builds, and premium reflection circles.",
+            ],
+            "expected_impact": "Good for mission believers; validate after core subscriptions and sessions.",
+        }
+
+    async def _research_ip_licensing(self, metrics: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "offer": "White-labelled Ora workflows for coaches, communities, and social enterprises.",
+            "next_steps": [
+                "Identify 10 aligned organisations already serving wellbeing or transformation audiences.",
+                "Package a limited pilot license with brand controls and data protection terms.",
+                "Price pilots at $500-$2,000/month depending on seat count and customisation.",
+            ],
+            "expected_impact": "High-ticket but requires stronger onboarding, compliance, and support capacity.",
+        }
+
+    def _prioritize_revenue_streams(self, metrics: Dict[str, Any], research: Dict[str, Any]) -> List[Dict[str, Any]]:
+        return [
+            {
+                "name": "Corporate wellness plan",
+                "rank": 1,
+                "why_now": "B2B can create meaningful MRR with one relationship while user count is still small.",
+                "price": "$8/seat/month, minimum 10 seats",
+                "research": research["b2b_corporate_wellness"],
+            },
+            {
+                "name": "One-time Ora Sessions",
+                "rank": 2,
+                "why_now": "Immediate cash conversion without needing subscription habit formation.",
+                "price": "$49 clarity session / $99 deep work session",
+                "research": {"offer": "Premium 1:1 coaching session via Stripe Checkout."},
+            },
+            {
+                "name": "Developer API tier",
+                "rank": 3,
+                "why_now": "Turns Ora's intelligence into a platform revenue stream with low marginal cost.",
+                "price": "$29/month developer, $99/month scale",
+                "research": research["api_access_monetization"],
+            },
+            {
+                "name": "Grant pipeline",
+                "rank": 4,
+                "why_now": "High mission fit, but slow sales cycle.",
+                "price": "Non-dilutive grants",
+                "research": research["grants"],
+            },
+        ]
+
+    async def _activate_top_streams(self, streams: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        activations: List[Dict[str, Any]] = []
+        for stream in streams[:3]:
+            try:
+                if stream["name"] == "Corporate wellness plan":
+                    checkout = await create_corporate_plan_checkout(
+                        org_name="Founding Corporate Wellness Pilot",
+                        seats=10,
+                        contact_email="growth@connectome.app",
+                    )
+                elif stream["name"] == "One-time Ora Sessions":
+                    checkout = await create_ora_session_payment("growth-demo", "clarity")
+                elif stream["name"] == "Developer API tier":
+                    checkout = await create_api_access_checkout("growth-demo", "developer")
+                else:
+                    checkout = {"configured": False, "checkout_url": None}
+                activations.append({"stream": stream["name"], "checkout": checkout})
+            except Exception as exc:
+                logger.warning("CGO activation failed for %s: %s", stream["name"], exc)
+                activations.append({"stream": stream["name"], "error": str(exc)})
+        return activations
+
+    def _build_action_plan(self, streams: List[Dict[str, Any]], metrics: Dict[str, Any]) -> List[Dict[str, Any]]:
+        return [
+            {
+                "priority": 1,
+                "action": "Close one corporate wellness pilot: target 10-25 seats at $8/seat/month.",
+                "owner": "CGO + CMO",
+                "next_step": "Create the team landing page and outbound list of 20 aligned founders.",
+                "success_metric": "$80-$200 MRR from first B2B customer.",
+            },
+            {
+                "priority": 2,
+                "action": "Launch Ora Sessions as one-off paid coaching checkout.",
+                "owner": "CGO + CPO",
+                "next_step": "Add in-app CTA after deep reflective moments and on the upgrade page.",
+                "success_metric": "3 paid sessions in 14 days.",
+            },
+            {
+                "priority": 3,
+                "action": "Ship Developer API paid tier with keys, docs, and 10k included calls.",
+                "owner": "CGO + CTO",
+                "next_step": "Add API key issuance, usage tracking, and docs for the first 3 endpoints.",
+                "success_metric": "2 developer subscribers in 30 days.",
+            },
+            {
+                "priority": 4,
+                "action": "Convert high-engagement free users ethically at natural value moments.",
+                "owner": "CGO + CMO",
+                "next_step": "Segment free users by engagement and add mission-framed upgrade prompts.",
+                "success_metric": "Free-to-paid conversion above 5% among active users.",
+            },
+        ]
+
+    def _stage(self, metrics: Dict[str, Any]) -> str:
+        if metrics.get("total_revenue_cents", 0) <= 0 and metrics.get("paid_users", 0) <= 0:
+            return "pre-revenue: validate willingness-to-pay immediately"
+        if metrics.get("mrr_cents_est", 0) < 100_000:
+            return "early revenue: push to first $1k MRR"
+        return "growth: scale validated channels"
+
+
+async def run_cgo_growth_analysis() -> Dict[str, Any]:
+    """Convenience entrypoint for routes, crons, and scripts."""
+    agent = CGOAgent()
+    return await agent.act()

--- a/ora/agents/executive_council.py
+++ b/ora/agents/executive_council.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 ASCENSION_CHAT_ID = os.getenv("ASCENSION_CHANNEL_ID", "-1001234567890")  # @ascensionai channel
 TELEGRAM_CHAT_ID = 5716959016
 
-AGENT_NAMES = ["cfo", "cmo", "cpo", "cto", "coo", "community", "strategy", "cuxd"]
+AGENT_NAMES = ["cfo", "cgo", "cmo", "cpo", "cto", "coo", "community", "strategy", "cuxd"]
 
 
 class ExecutiveCouncil(BaseExecutiveAgent):

--- a/ora/payments/growth_billing.py
+++ b/ora/payments/growth_billing.py
@@ -1,0 +1,196 @@
+"""
+Growth billing helpers for Ora/Connectome revenue experiments.
+
+These functions use Stripe Checkout Sessions with inline price_data so new growth
+streams can be activated without pre-created Stripe Price IDs. If
+STRIPE_SECRET_KEY is not configured they return safe mock checkout data instead
+of failing the product surface.
+"""
+
+import logging
+import os
+from typing import Any, Dict
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+STRIPE_API_BASE = "https://api.stripe.com/v1"
+FRONTEND_BASE_URL = os.getenv("FRONTEND_BASE_URL", "https://connectome.app")
+CURRENCY = "usd"
+
+API_ACCESS_PLANS: Dict[str, Dict[str, Any]] = {
+    "developer": {
+        "name": "Ora Developer API — 10k calls",
+        "unit_amount": 2900,
+        "included_calls": 10_000,
+        "interval": "month",
+    },
+    "scale": {
+        "name": "Ora Developer API — 100k calls",
+        "unit_amount": 9900,
+        "included_calls": 100_000,
+        "interval": "month",
+    },
+}
+
+ORA_SESSION_TYPES: Dict[str, Dict[str, Any]] = {
+    "clarity": {
+        "name": "Ora Clarity Session",
+        "description": "One premium 1:1 coaching session with Ora's human-flourishing workflow.",
+        "unit_amount": 4900,
+    },
+    "deep_work": {
+        "name": "Ora Deep Work Session",
+        "description": "A focused 1:1 session for goals, blockers, and next-action architecture.",
+        "unit_amount": 9900,
+    },
+}
+
+
+class GrowthBillingError(Exception):
+    """Raised when Stripe returns an error for a growth billing action."""
+
+    def __init__(self, message: str, status: int = 400, code: str = ""):
+        super().__init__(message)
+        self.status = status
+        self.code = code
+
+
+def _stripe_key() -> str:
+    return os.getenv("STRIPE_SECRET_KEY", "")
+
+
+def _mock_checkout(kind: str, metadata: Dict[str, Any]) -> Dict[str, Any]:
+    logger.warning("STRIPE_SECRET_KEY is not configured; returning mock %s checkout", kind)
+    return {
+        "configured": False,
+        "mock": True,
+        "id": f"mock_{kind}_checkout",
+        "checkout_url": f"{FRONTEND_BASE_URL}/billing/mock?stream={kind}",
+        "metadata": metadata,
+        "note": "Set STRIPE_SECRET_KEY in Railway to create live Stripe Checkout Sessions.",
+    }
+
+
+async def _create_checkout_session(data: Dict[str, Any]) -> Dict[str, Any]:
+    key = _stripe_key()
+    if not key:
+        return _mock_checkout(str(data.get("metadata[growth_stream]", "growth")), dict(data))
+
+    headers = {
+        "Authorization": f"Bearer {key}",
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Stripe-Version": "2024-04-10",
+    }
+    async with httpx.AsyncClient(timeout=30) as client:
+        resp = await client.post(f"{STRIPE_API_BASE}/checkout/sessions", headers=headers, data=data)
+
+    body = resp.json()
+    if resp.status_code >= 400:
+        error = body.get("error", {})
+        raise GrowthBillingError(
+            error.get("message", "Stripe Checkout Session creation failed"),
+            status=resp.status_code,
+            code=error.get("code", ""),
+        )
+
+    return {
+        "configured": True,
+        "mock": False,
+        "id": body.get("id"),
+        "checkout_url": body.get("url"),
+        "status": body.get("status"),
+        "metadata": {k: v for k, v in data.items() if k.startswith("metadata[")},
+    }
+
+
+async def create_api_access_checkout(user_id: str, plan: str) -> Dict[str, Any]:
+    """Create a Stripe Checkout Session for developer API access."""
+    plan_key = (plan or "developer").lower()
+    if plan_key not in API_ACCESS_PLANS:
+        raise ValueError(f"Unknown API access plan: {plan}")
+
+    cfg = API_ACCESS_PLANS[plan_key]
+    data: Dict[str, Any] = {
+        "mode": "subscription",
+        "client_reference_id": str(user_id),
+        "line_items[0][quantity]": "1",
+        "line_items[0][price_data][currency]": CURRENCY,
+        "line_items[0][price_data][unit_amount]": str(cfg["unit_amount"]),
+        "line_items[0][price_data][recurring][interval]": cfg["interval"],
+        "line_items[0][price_data][product_data][name]": cfg["name"],
+        "line_items[0][price_data][product_data][description]": (
+            f"Monthly developer API access with {cfg['included_calls']:,} included calls."
+        ),
+        "allow_promotion_codes": "true",
+        "success_url": f"{FRONTEND_BASE_URL}/developer/billing/success?session_id={{CHECKOUT_SESSION_ID}}",
+        "cancel_url": f"{FRONTEND_BASE_URL}/developer/billing",
+        "metadata[growth_stream]": "developer_api",
+        "metadata[connectome_user_id]": str(user_id),
+        "metadata[plan]": plan_key,
+        "subscription_data[metadata][growth_stream]": "developer_api",
+        "subscription_data[metadata][connectome_user_id]": str(user_id),
+        "subscription_data[metadata][included_calls]": str(cfg["included_calls"]),
+    }
+    return await _create_checkout_session(data)
+
+
+async def create_corporate_plan_checkout(org_name: str, seats: int, contact_email: str) -> Dict[str, Any]:
+    """Create a Stripe Checkout Session for corporate wellness bulk seats."""
+    safe_org = (org_name or "Connectome Corporate Partner").strip()[:120]
+    seat_count = max(int(seats or 10), 10)
+    email = (contact_email or "").strip()
+
+    data: Dict[str, Any] = {
+        "mode": "subscription",
+        "customer_email": email,
+        "client_reference_id": f"corporate:{safe_org}",
+        "line_items[0][quantity]": str(seat_count),
+        "line_items[0][price_data][currency]": CURRENCY,
+        "line_items[0][price_data][unit_amount]": "800",
+        "line_items[0][price_data][recurring][interval]": "month",
+        "line_items[0][price_data][product_data][name]": "Ora Corporate Wellness Seat",
+        "line_items[0][price_data][product_data][description]": (
+            "Bulk Ora access for workplace clarity, fulfilment, and aligned action. Minimum 10 seats."
+        ),
+        "allow_promotion_codes": "true",
+        "success_url": f"{FRONTEND_BASE_URL}/corporate/success?session_id={{CHECKOUT_SESSION_ID}}",
+        "cancel_url": f"{FRONTEND_BASE_URL}/corporate",
+        "metadata[growth_stream]": "corporate_wellness",
+        "metadata[org_name]": safe_org,
+        "metadata[seats]": str(seat_count),
+        "metadata[contact_email]": email,
+        "subscription_data[metadata][growth_stream]": "corporate_wellness",
+        "subscription_data[metadata][org_name]": safe_org,
+        "subscription_data[metadata][seats]": str(seat_count),
+    }
+    if not email:
+        data.pop("customer_email")
+    return await _create_checkout_session(data)
+
+
+async def create_ora_session_payment(user_id: str, session_type: str) -> Dict[str, Any]:
+    """Create a one-off Stripe Checkout Session for a premium Ora coaching session."""
+    type_key = (session_type or "clarity").lower()
+    if type_key not in ORA_SESSION_TYPES:
+        raise ValueError(f"Unknown Ora session type: {session_type}")
+
+    cfg = ORA_SESSION_TYPES[type_key]
+    data: Dict[str, Any] = {
+        "mode": "payment",
+        "client_reference_id": str(user_id),
+        "line_items[0][quantity]": "1",
+        "line_items[0][price_data][currency]": CURRENCY,
+        "line_items[0][price_data][unit_amount]": str(cfg["unit_amount"]),
+        "line_items[0][price_data][product_data][name]": cfg["name"],
+        "line_items[0][price_data][product_data][description]": cfg["description"],
+        "success_url": f"{FRONTEND_BASE_URL}/sessions/success?session_id={{CHECKOUT_SESSION_ID}}",
+        "cancel_url": f"{FRONTEND_BASE_URL}/sessions",
+        "metadata[growth_stream]": "ora_session",
+        "metadata[connectome_user_id]": str(user_id),
+        "metadata[session_type]": type_key,
+        "payment_intent_data[metadata][growth_stream]": "ora_session",
+        "payment_intent_data[metadata][connectome_user_id]": str(user_id),
+    }
+    return await _create_checkout_session(data)


### PR DESCRIPTION
## Summary
- Add CGO executive agent for revenue growth analysis, research streams, prioritized action plans, and safe activation attempts
- Add growth billing helpers for Developer API, Corporate Wellness, and Ora Session Stripe Checkout flows with mock fallback when STRIPE_SECRET_KEY is missing
- Add /api/cgo routes and register them in FastAPI; include CGO in Executive Council reports

## Verification
- python3 -m py_compile api/routes/cgo.py ora/agents/cgo_agent.py ora/payments/growth_billing.py main.py ora/agents/executive_council.py

## Notes
- Stripe secret is read from os.getenv("STRIPE_SECRET_KEY") only; no keys are hardcoded
- Billing helpers gracefully return mock checkout data when Stripe is not configured