### PR TITLE
feat: add integral synthesis agent

### DIFF
--- a/api/routes/executive.py
+++ b/api/routes/executive.py
@@ -25,7 +25,7 @@ router = APIRouter(prefix="/api/executive", tags=["executive"])
 ADMIN_TOKEN = os.getenv("ADMIN_TOKEN", "connectome-admin-secret")
 LOG_DIR = "/Users/avielcarlos/.openclaw/workspace/tmp/executive_council"
 
-AGENT_NAMES = ["cfo", "cmo", "cpo", "cto", "coo", "community", "strategy", "executive_council"]
+AGENT_NAMES = ["cfo", "cgo", "cmo", "cpo", "cto", "coo", "community", "strategy", "executive_council"]
 
 
 def _require_admin(x_admin_token: str = Header(default="")):
@@ -258,6 +258,7 @@ async def run_agent(
 
     valid_agents = {
         "cfo": "ora.agents.cfo_agent.CFOAgent",
+        "cgo": "ora.agents.cgo_agent.CGOAgent",
         "cmo": "ora.agents.cmo_agent.CMOAgent",
         "cpo": "ora.agents.cpo_agent.CPOAgent",
         "cto": "ora.agents.cto_agent.CTOAgent",

--- a/api/routes/knowledge.py
+++ b/api/routes/knowledge.py
@@ -1,0 +1,64 @@
+"""Knowledge routes — Integral synthesis conflict resolution."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+from fastapi import APIRouter, Header, HTTPException
+from pydantic import BaseModel, Field
+
+from ora.agents.agent_memory import AgentInsight, agent_memory_bus
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/knowledge", tags=["knowledge"])
+
+ADMIN_TOKEN = os.getenv("ADMIN_TOKEN", os.getenv("ADMIN_SECRET", "connectome-admin-secret"))
+
+
+class ConflictResolutionRequest(BaseModel):
+    conflict_id: str = Field(..., min_length=4)
+    resolution: str = Field(..., min_length=2)
+    source_of_truth: str = Field(..., min_length=2)
+
+
+def _require_admin(x_admin_token: str = Header(default="")) -> None:
+    if x_admin_token != ADMIN_TOKEN:
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+
+@router.post("/conflict-resolve")
+async def resolve_knowledge_conflict(
+    body: ConflictResolutionRequest,
+    x_admin_token: str = Header(default=""),
+) -> Dict[str, Any]:
+    """
+    Store Avi's resolution to a knowledge conflict as a permanent memory-bus insight.
+    """
+    _require_admin(x_admin_token)
+    payload = {
+        "conflict_id": body.conflict_id,
+        "resolution": body.resolution,
+        "source_of_truth": body.source_of_truth,
+        "resolved_by": "avi",
+        "resolved_at": datetime.now(timezone.utc).isoformat(),
+    }
+    insight = AgentInsight(
+        source_agent="avi",
+        domain="integral_knowledge",
+        insight_type="conflict_resolution",
+        content=json.dumps(payload, ensure_ascii=False),
+        confidence=1.0,
+        action_required=False,
+        target_agents=[],
+        expires_at=datetime.now(timezone.utc),
+    )
+    insight_id = await agent_memory_bus.publish(insight)
+    if not insight_id:
+        logger.warning("Failed to publish knowledge conflict resolution: %s", body.conflict_id)
+        raise HTTPException(status_code=500, detail="Unable to store conflict resolution")
+    await agent_memory_bus.promote_to_permanent(insight_id)
+    return {"status": "stored", "insight_id": insight_id, **payload}

--- a/main.py
+++ b/main.py
@@ -54,6 +54,7 @@ from api.routes import ora_autonomy as ora_autonomy_routes
 from api.routes import onboarding as onboarding_routes
 from api.routes import surfaces as surfaces_routes
 from api.routes import gamification as gamification_routes
+from api.routes import knowledge as knowledge_routes
 try:
     from api.routes import ioo as ioo_routes
     _ioo_available = True
@@ -286,6 +287,7 @@ app.include_router(ora_autonomy_routes.router)
 app.include_router(onboarding_routes.router)
 app.include_router(surfaces_routes.router)
 app.include_router(gamification_routes.router)
+app.include_router(knowledge_routes.router)
 if _services_available and services_routes:
     app.include_router(services_routes.router)
 if _executive_available and executive_routes:

--- a/ora/agents/agent_memory.py
+++ b/ora/agents/agent_memory.py
@@ -1,0 +1,276 @@
+"""
+Compound Intelligence Layer — shared memory bus for Ora's agent council.
+
+Every executive agent can publish structured insights after a run. Other agents
+can read relevant cross-domain context before planning. Insights expire after
+7 days by default unless promoted to permanent learnings.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from core.database import execute, fetch, fetchrow
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TTL_DAYS = 7
+
+
+@dataclass
+class AgentInsight:
+    source_agent: str
+    domain: str
+    insight_type: str
+    content: str
+    confidence: float = 0.8
+    action_required: bool = False
+    target_agents: List[str] = field(default_factory=list)
+    expires_at: Optional[datetime] = None
+    id: Optional[str] = None
+    created_at: Optional[datetime] = None
+    promoted_at: Optional[datetime] = None
+
+    def __post_init__(self) -> None:
+        if self.expires_at is None:
+            self.expires_at = datetime.now(timezone.utc) + timedelta(days=DEFAULT_TTL_DAYS)
+        self.confidence = max(0.0, min(1.0, float(self.confidence)))
+        self.target_agents = [a.strip().lower() for a in (self.target_agents or []) if a]
+        self.source_agent = self.source_agent.strip().lower()
+        self.domain = self.domain.strip().lower()
+        self.insight_type = self.insight_type.strip().lower()
+
+    @classmethod
+    def from_record(cls, row: Any) -> "AgentInsight":
+        return cls(
+            id=str(row["id"]),
+            source_agent=row["source_agent"],
+            domain=row["domain"],
+            insight_type=row["insight_type"],
+            content=row["content"],
+            confidence=float(row["confidence"]),
+            action_required=bool(row["action_required"]),
+            target_agents=list(row["target_agents"] or []),
+            expires_at=row["expires_at"],
+            created_at=row["created_at"],
+            promoted_at=row["promoted_at"],
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "source_agent": self.source_agent,
+            "domain": self.domain,
+            "insight_type": self.insight_type,
+            "content": self.content,
+            "confidence": self.confidence,
+            "action_required": self.action_required,
+            "target_agents": self.target_agents,
+            "expires_at": self.expires_at.isoformat() if self.expires_at else None,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "promoted_at": self.promoted_at.isoformat() if self.promoted_at else None,
+        }
+
+
+class AgentMemoryBus:
+    """PostgreSQL-backed shared knowledge bus for executive agents."""
+
+    def __init__(self) -> None:
+        self._ready = False
+
+    async def ensure_schema(self) -> None:
+        if self._ready:
+            return
+        await execute('CREATE EXTENSION IF NOT EXISTS "pgcrypto"')
+        await execute(
+            """
+            CREATE TABLE IF NOT EXISTS agent_insights (
+                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                source_agent TEXT NOT NULL,
+                domain TEXT NOT NULL,
+                insight_type TEXT NOT NULL,
+                content TEXT NOT NULL,
+                confidence DOUBLE PRECISION DEFAULT 0.8,
+                action_required BOOLEAN DEFAULT FALSE,
+                target_agents TEXT[] DEFAULT ARRAY[]::TEXT[],
+                expires_at TIMESTAMPTZ NOT NULL,
+                promoted_at TIMESTAMPTZ,
+                created_at TIMESTAMPTZ DEFAULT NOW()
+            )
+            """
+        )
+        await execute(
+            """
+            CREATE TABLE IF NOT EXISTS agent_trigger_queue (
+                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                insight_id UUID REFERENCES agent_insights(id) ON DELETE CASCADE,
+                source_agent TEXT NOT NULL,
+                target_agent TEXT NOT NULL,
+                reason TEXT,
+                status TEXT DEFAULT 'pending',
+                created_at TIMESTAMPTZ DEFAULT NOW(),
+                consumed_at TIMESTAMPTZ
+            )
+            """
+        )
+        await execute(
+            "CREATE INDEX IF NOT EXISTS idx_agent_insights_recent ON agent_insights (created_at DESC)"
+        )
+        await execute(
+            "CREATE INDEX IF NOT EXISTS idx_agent_insights_targets ON agent_insights USING GIN (target_agents)"
+        )
+        await execute(
+            "CREATE INDEX IF NOT EXISTS idx_agent_trigger_queue_pending ON agent_trigger_queue (status, target_agent, created_at DESC)"
+        )
+        self._ready = True
+
+    async def publish(self, insight: AgentInsight) -> Optional[str]:
+        """Publish an insight and enqueue any required target-agent follow-ups."""
+        try:
+            await self.ensure_schema()
+            row = await fetchrow(
+                """
+                INSERT INTO agent_insights (
+                    source_agent, domain, insight_type, content, confidence,
+                    action_required, target_agents, expires_at
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, $7::TEXT[], $8)
+                RETURNING id, created_at
+                """,
+                insight.source_agent,
+                insight.domain,
+                insight.insight_type,
+                insight.content,
+                insight.confidence,
+                insight.action_required,
+                insight.target_agents,
+                insight.expires_at,
+            )
+            if not row:
+                return None
+            insight.id = str(row["id"])
+            insight.created_at = row["created_at"]
+
+            if insight.action_required:
+                for agent in insight.target_agents:
+                    await execute(
+                        """
+                        INSERT INTO agent_trigger_queue (insight_id, source_agent, target_agent, reason)
+                        VALUES ($1, $2, $3, $4)
+                        """,
+                        UUID(insight.id),
+                        insight.source_agent,
+                        agent,
+                        insight.content[:500],
+                    )
+            return insight.id
+        except Exception as exc:
+            logger.warning("AgentMemoryBus.publish failed: %s", exc)
+            return None
+
+    async def read_for(self, agent_name: str, domains: Optional[List[str]] = None) -> List[AgentInsight]:
+        """Read active insights relevant to an agent and optional domains."""
+        try:
+            await self.ensure_schema()
+            agent = agent_name.lower()
+            domain_filter = [d.lower() for d in domains] if domains else None
+            if domain_filter:
+                rows = await fetch(
+                    """
+                    SELECT * FROM agent_insights
+                    WHERE (expires_at > NOW() OR promoted_at IS NOT NULL)
+                      AND source_agent != $1
+                      AND domain = ANY($2::TEXT[])
+                      AND (target_agents = ARRAY[]::TEXT[] OR $1 = ANY(target_agents))
+                    ORDER BY action_required DESC, confidence DESC, created_at DESC
+                    LIMIT 25
+                    """,
+                    agent,
+                    domain_filter,
+                )
+            else:
+                rows = await fetch(
+                    """
+                    SELECT * FROM agent_insights
+                    WHERE (expires_at > NOW() OR promoted_at IS NOT NULL)
+                      AND source_agent != $1
+                      AND (target_agents = ARRAY[]::TEXT[] OR $1 = ANY(target_agents))
+                    ORDER BY action_required DESC, confidence DESC, created_at DESC
+                    LIMIT 25
+                    """,
+                    agent,
+                )
+            return [AgentInsight.from_record(row) for row in rows]
+        except Exception as exc:
+            logger.debug("AgentMemoryBus.read_for failed: %s", exc)
+            return []
+
+    async def read_all_recent(self, hours: int = 168) -> List[AgentInsight]:
+        """Read all non-expired insights created within the requested window."""
+        try:
+            await self.ensure_schema()
+            rows = await fetch(
+                """
+                SELECT * FROM agent_insights
+                WHERE created_at > NOW() - ($1::INT * INTERVAL '1 hour')
+                  AND (expires_at > NOW() OR promoted_at IS NOT NULL)
+                ORDER BY created_at DESC
+                LIMIT 250
+                """,
+                int(hours),
+            )
+            return [AgentInsight.from_record(row) for row in rows]
+        except Exception as exc:
+            logger.debug("AgentMemoryBus.read_all_recent failed: %s", exc)
+            return []
+
+    async def promote_to_permanent(self, insight_id: str) -> bool:
+        try:
+            await self.ensure_schema()
+            await execute(
+                "UPDATE agent_insights SET promoted_at = NOW(), expires_at = NOW() + INTERVAL '100 years' WHERE id = $1",
+                UUID(insight_id),
+            )
+            return True
+        except Exception as exc:
+            logger.warning("AgentMemoryBus.promote_to_permanent failed: %s", exc)
+            return False
+
+    async def read_trigger_queue(self, status: str = "pending") -> List[Dict[str, Any]]:
+        """Read pending agent follow-up triggers for council fast-tracking."""
+        try:
+            await self.ensure_schema()
+            rows = await fetch(
+                """
+                SELECT q.*, i.domain, i.insight_type, i.confidence
+                FROM agent_trigger_queue q
+                LEFT JOIN agent_insights i ON i.id = q.insight_id
+                WHERE q.status = $1
+                ORDER BY q.created_at ASC
+                LIMIT 100
+                """,
+                status,
+            )
+            return [dict(row) for row in rows]
+        except Exception as exc:
+            logger.debug("AgentMemoryBus.read_trigger_queue failed: %s", exc)
+            return []
+
+    async def mark_trigger_consumed(self, trigger_id: str) -> bool:
+        try:
+            await self.ensure_schema()
+            await execute(
+                "UPDATE agent_trigger_queue SET status = 'consumed', consumed_at = NOW() WHERE id = $1",
+                UUID(trigger_id),
+            )
+            return True
+        except Exception as exc:
+            logger.debug("AgentMemoryBus.mark_trigger_consumed failed: %s", exc)
+            return False
+
+
+agent_memory_bus = AgentMemoryBus()

--- a/ora/agents/base_executive_agent.py
+++ b/ora/agents/base_executive_agent.py
@@ -21,6 +21,30 @@ LOG_DIR = "/Users/avielcarlos/.openclaw/workspace/tmp/executive_council"
 API_BASE = "https://connectome-api-production.up.railway.app"
 
 
+AGENT_DOMAINS = {
+    "cfo": "revenue",
+    "cgo": "growth",
+    "cmo": "growth",
+    "cpo": "product",
+    "cto": "tech",
+    "coo": "ops",
+    "community": "community",
+    "strategy": "strategy",
+    "executive_council": "strategy",
+}
+
+AGENT_COLLABORATORS = {
+    "cfo": ["cgo", "cmo", "coo"],
+    "cmo": ["cgo", "cpo", "community"],
+    "cpo": ["cgo", "cto", "community"],
+    "cto": ["cgo", "cpo", "coo"],
+    "coo": ["cfo", "cgo", "cmo", "cpo", "cto", "community", "strategy"],
+    "cgo": ["cfo", "cmo", "cpo", "cto", "community"],
+    "strategy": ["cfo", "cgo", "cmo", "cpo", "cto", "coo", "community"],
+    "community": ["cgo", "cmo", "cpo", "strategy"],
+}
+
+
 class BaseExecutiveAgent(ABC):
     """
     Interface all executive agents implement.
@@ -30,15 +54,29 @@ class BaseExecutiveAgent(ABC):
     - Analyzes data in that domain
     - Reports insights in plain English
     - Can take safe autonomous actions
+    - Reads and writes to the compound intelligence bus
     - Teaches Ora what it learns via /api/ora/learn
     """
 
     name: str = "base"
     display_name: str = "Base Agent"
+    domain: str = "strategy"
+    personality: str = "Mission-aligned executive intelligence serving Ora's AI OS for human flourishing."
+    compound_system_prompt: str = (
+        "Ora is an AI OS for human flourishing. Avi is The Spark — the visionary "
+        "initiating force. The agent team is a living executive council that "
+        "compounds collective intelligence: every agent reads what the others found, "
+        "references cross-domain signals where relevant, and publishes structured "
+        "insights back to the shared memory bus. Outputs should include "
+        "agent_insights_published: list[str] and cross_agent_context_used: list[str]."
+    )
 
     def __init__(self):
         self._jwt_token: Optional[str] = None
         self._telegram_token: Optional[str] = None
+        self.domain = getattr(self, "domain", AGENT_DOMAINS.get(self.name, "strategy"))
+        self._last_compound_context_used: List[str] = []
+        self._last_agent_insights_published: List[str] = []
         os.makedirs(LOG_DIR, exist_ok=True)
 
     # ─── Interface ──────────────────────────────────────────────────────────
@@ -64,6 +102,116 @@ class BaseExecutiveAgent(ABC):
         ...
 
     # ─── Shared helpers ─────────────────────────────────────────────────────
+
+    async def compound_context(self, domains: Optional[List[str]] = None) -> List[Dict[str, Any]]:
+        """
+        Pull relevant cross-agent insights from the compound memory bus.
+        Gracefully returns [] if the bus/database is unavailable.
+        """
+        try:
+            from ora.agents.agent_memory import agent_memory_bus
+
+            insights = await agent_memory_bus.read_for(self.name, domains=domains)
+            context = [insight.to_dict() for insight in insights]
+            self._last_compound_context_used = [
+                f"{item['source_agent']}:{item['insight_type']}:{item['content'][:120]}"
+                for item in context
+            ]
+            return context
+        except Exception as e:
+            logger.debug(f"{self.name}: compound context unavailable: {e}")
+            self._last_compound_context_used = []
+            return []
+
+    def compound_personality_prompt(self) -> str:
+        """Richer prompt/context block for LLM-backed executive planning."""
+        collaborators = ", ".join(AGENT_COLLABORATORS.get(self.name, [])) or "the full council"
+        return (
+            f"{self.compound_system_prompt}\n\n"
+            f"You are {self.display_name} ({self.name}), domain={self.domain}. "
+            f"Personality: {self.personality} "
+            f"Primary collaborators to cross-reference: {collaborators}."
+        )
+
+    async def publish_agent_insights(self, data: Dict[str, Any]) -> List[str]:
+        """Extract and publish this run's key findings to the shared bus."""
+        try:
+            from ora.agents.agent_memory import AgentInsight, agent_memory_bus
+
+            insights = self._extract_insights_from_report(data)
+            published: List[str] = []
+            for insight in insights[:5]:
+                insight_id = await agent_memory_bus.publish(insight)
+                if insight_id:
+                    published.append(insight.content)
+            self._last_agent_insights_published = published
+            return published
+        except Exception as e:
+            logger.debug(f"{self.name}: publish_agent_insights failed: {e}")
+            self._last_agent_insights_published = []
+            return []
+
+    def _extract_insights_from_report(self, data: Dict[str, Any]) -> List[Any]:
+        """Best-effort conversion of heterogeneous agent reports into bus insights."""
+        from ora.agents.agent_memory import AgentInsight
+
+        domain = getattr(self, "domain", AGENT_DOMAINS.get(self.name, "strategy"))
+        collaborators = AGENT_COLLABORATORS.get(self.name, [])
+        insights: List[AgentInsight] = []
+
+        def add(insight_type: str, content: str, confidence: float = 0.78, action_required: bool = False, targets: Optional[List[str]] = None) -> None:
+            content = " ".join(str(content).split())[:1000]
+            if content:
+                insights.append(
+                    AgentInsight(
+                        source_agent=self.name,
+                        domain=domain,
+                        insight_type=insight_type,
+                        content=content,
+                        confidence=confidence,
+                        action_required=action_required,
+                        target_agents=targets or collaborators[:3],
+                    )
+                )
+
+        if not isinstance(data, dict):
+            add("finding", str(data))
+            return insights
+
+        if data.get("strategic_synthesis"):
+            add("decision", data["strategic_synthesis"], 0.9, True, AGENT_COLLABORATORS.get("strategy", []))
+        if data.get("mandate"):
+            add("finding", data["mandate"], 0.74)
+
+        for key in ("top_priorities", "key_opportunities", "recommended_actions", "prioritized_action_plan"):
+            value = data.get(key)
+            if isinstance(value, list):
+                for item in value[:2]:
+                    text = item.get("action") if isinstance(item, dict) else item
+                    add("opportunity" if "opportun" in key or "action" in key else "decision", text, 0.82, "action" in key, collaborators[:3])
+
+        for key in ("key_risks", "risks"):
+            value = data.get(key)
+            if isinstance(value, list):
+                for item in value[:2]:
+                    add("risk", item, 0.84, True, collaborators[:3])
+
+        metric_fragments = []
+        metrics = data.get("metrics") if isinstance(data.get("metrics"), dict) else data
+        for key in (
+            "mrr_usd", "arr_usd", "revenue_last_30d_usd", "total_users", "new_users_7d",
+            "active_users_7d", "weekly_growth_rate_pct", "paid_users", "conversion_rate_pct",
+            "system_health_score", "community_health_score", "roadmap_health_score",
+        ):
+            if key in metrics:
+                metric_fragments.append(f"{key}={metrics.get(key)}")
+        if metric_fragments:
+            add("finding", f"{self.display_name} metrics: " + ", ".join(metric_fragments), 0.8)
+
+        if not insights:
+            summary = json.dumps(data, default=str)[:700]
+            add("finding", f"{self.display_name} completed run: {summary}", 0.7)
+        return insights
 
     async def teach_ora(self, insight: str, confidence: float = 0.8) -> bool:
         """
@@ -97,10 +245,14 @@ class BaseExecutiveAgent(ABC):
             return False
 
     async def save_report(self, data: Dict[str, Any], filename: Optional[str] = None) -> str:
-        """Save a report dict as JSON to the executive_council log dir."""
+        """Save a report dict and publish its key findings to the intelligence bus."""
         fname = filename or f"{self.name}_report.json"
         path = os.path.join(LOG_DIR, fname)
         data["_saved_at"] = datetime.now(timezone.utc).isoformat()
+        if "cross_agent_context_used" not in data:
+            data["cross_agent_context_used"] = self._last_compound_context_used
+        if "agent_insights_published" not in data:
+            data["agent_insights_published"] = await self.publish_agent_insights(data)
         with open(path, "w") as f:
             json.dump(data, f, indent=2, default=str)
         return path

--- a/ora/agents/cfo_agent.py
+++ b/ora/agents/cfo_agent.py
@@ -35,6 +35,12 @@ class CFOAgent(BaseExecutiveAgent):
 
     name = "cfo"
     display_name = "CFO Agent"
+    domain = "revenue"
+    personality = (
+        "Treasurer of a mission-driven AI OS. Obsessed with sustainability, validates "
+        "CGO revenue bets with unit economics, and cross-references CMO acquisition "
+        "costs against CLV before recommending spend."
+    )
 
     # ─── Stripe helpers ─────────────────────────────────────────────────────
 
@@ -58,6 +64,7 @@ class CFOAgent(BaseExecutiveAgent):
 
     async def analyze(self) -> Dict[str, Any]:
         """Pull Stripe metrics and compute financial KPIs."""
+        await self.compound_context()
         now = datetime.now(timezone.utc)
         thirty_days_ago = int((now - timedelta(days=30)).timestamp())
         seven_days_ago = int((now - timedelta(days=7)).timestamp())

--- a/ora/agents/cgo_agent.py
+++ b/ora/agents/cgo_agent.py
@@ -37,8 +37,14 @@ class CGOAgent(BaseExecutiveAgent):
 
     name = "cgo"
     display_name = "CGO Agent"
+    domain = "growth"
+    personality = (
+        "Revenue engine: aggressive, creative, and mission-aligned. Uses CFO data, "
+        "CMO channels, CPO features, and CTO capacity to find compound growth levers."
+    )
 
     async def analyze(self) -> Dict[str, Any]:
+        await self.compound_context()
         now = datetime.now(timezone.utc)
         metrics = await self._get_revenue_metrics()
         research = {

--- a/ora/agents/cgo_agent.py
+++ b/ora/agents/cgo_agent.py
@@ -1,5 +1,5 @@
 """
-CGO Agent — Chief Growth Officer for Connectome/Ora.
+CGO Agent — Chief Growth Officer for Ascension Technologies / Ora.
 
 Mandate: aggressively and creatively grow revenue while protecting the
 non-profit mission. The CGO never assumes a surface is impossible to monetize;
@@ -9,7 +9,7 @@ it finds ethical, legally sound revenue architecture around genuine value.
 import logging
 import os
 from datetime import datetime, timezone
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import httpx
 
@@ -27,13 +27,96 @@ ADMIN_TOKEN = os.getenv("ADMIN_TOKEN", os.getenv("ADMIN_SECRET", "connectome-adm
 
 class CGOAgent(BaseExecutiveAgent):
     """
-    Ora's Chief Growth Officer.
+    Ora's Chief Growth Officer for the entire Ascension Technologies ecosystem.
 
     Thinks like a startup growth hacker plus a mission-driven social enterprise:
     data-driven, commercial, fast-moving, and allergic to fake scarcity or
     deceptive billing. Revenue exists to make the human-flourishing mission
     durable.
     """
+
+    ecosystem_thesis = (
+        "We are Ascension Technologies. Connectome/iDo is ONE product. We also "
+        "have The Scilence, AI music, community, consulting, grants, corporate "
+        "clients, developer API access, Ora Sessions, DAO Founding Stewards, "
+        "events/retreats, and white-label Ora licensing. Revenue serves human "
+        "flourishing, not the reverse."
+    )
+
+    revenue_streams = [
+        {
+            "stream": "App subscriptions",
+            "target": "iDo / Connectome users",
+            "vehicle": "Stripe recurring subscriptions",
+            "near_term_offer": "Explorer/Premium personal fulfilment plan",
+        },
+        {
+            "stream": "Community membership",
+            "target": "Ascension community",
+            "vehicle": "Stripe recurring membership",
+            "near_term_offer": "Founding Steward membership and reflection circles",
+        },
+        {
+            "stream": "Corporate wellness",
+            "target": "HR/wellness teams",
+            "vehicle": "Stripe B2B checkout",
+            "near_term_offer": "Ora for Teams pilot at $8/seat/month",
+        },
+        {
+            "stream": "Developer API",
+            "target": "AI/wellness builders",
+            "vehicle": "Stripe API subscription",
+            "near_term_offer": "$29/month developer tier",
+        },
+        {
+            "stream": "Ora Sessions",
+            "target": "Individuals",
+            "vehicle": "Stripe one-off checkout",
+            "near_term_offer": "$49 clarity session / $99 deep work session",
+        },
+        {
+            "stream": "The Scilence",
+            "target": "Readers, sci-fi fans, publishers, agents",
+            "vehicle": "Pre-order page, publisher/agent outreach, self-publishing path",
+            "near_term_offer": "Pitch deck + sample pages + preorder waitlist",
+        },
+        {
+            "stream": "AI music",
+            "target": "Streaming audiences, sync libraries, wellness creators",
+            "vehicle": "DistroKid, sync licensing, creator collaborations",
+            "near_term_offer": "Release cadence + playlist/sync outreach",
+        },
+        {
+            "stream": "Grants",
+            "target": "Non-profit funders",
+            "vehicle": "Wellcome Trust, Google.org, Open Philanthropy, responsible AI grants",
+            "near_term_offer": "2-page concept note with safeguards and outcomes",
+        },
+        {
+            "stream": "Consulting/speaking",
+            "target": "Organisations and conferences",
+            "vehicle": "Direct outreach and paid engagements",
+            "near_term_offer": "AI + consciousness keynote/workshop menu",
+        },
+        {
+            "stream": "DAO Founding Stewards",
+            "target": "Early believers",
+            "vehicle": "Fiat-to-CP fast-track with transparent guardrails",
+            "near_term_offer": "Founding Steward pledge/membership",
+        },
+        {
+            "stream": "White-label Ora",
+            "target": "Wellness/health/coaching companies",
+            "vehicle": "B2B licensing",
+            "near_term_offer": "$500-$2,000/month pilot license",
+        },
+        {
+            "stream": "Events/retreats",
+            "target": "Community members",
+            "vehicle": "Eventbrite / Stripe tickets",
+            "near_term_offer": "Small virtual salon before physical retreats",
+        },
+    ]
 
     name = "cgo"
     display_name = "CGO Agent"
@@ -54,17 +137,25 @@ class CGOAgent(BaseExecutiveAgent):
             "api_access_monetization": await self._research_api_access(metrics),
             "community_membership": await self._research_community_membership(metrics),
             "ip_licensing_white_label": await self._research_ip_licensing(metrics),
+            "the_scilence": await self._research_the_scilence(metrics),
+            "ai_music": await self._research_ai_music(metrics),
+            "consulting_speaking": await self._research_consulting_speaking(metrics),
+            "dao_founding_stewards": await self._research_dao_founding_stewards(metrics),
+            "events_retreats": await self._research_events_retreats(metrics),
         }
         streams = self._prioritize_revenue_streams(metrics, research)
         activation = await self._activate_top_streams(streams)
+        growth_plan = self.multi_stream_growth_plan(metrics, research)
 
         report = {
             "agent": self.name,
             "analyzed_at": now.isoformat(),
-            "mandate": "Revenue serves the mission: fund Ora's non-profit AI OS for human flourishing.",
+            "mandate": self.ecosystem_thesis,
+            "ecosystem": self.revenue_streams,
             "metrics": metrics,
             "research": research,
             "prioritized_action_plan": self._build_action_plan(streams, metrics),
+            "multi_stream_30_day_growth_plan": growth_plan,
             "activated_revenue_streams": activation,
             "structured_growth_report": {
                 "stage": self._stage(metrics),
@@ -104,6 +195,7 @@ class CGOAgent(BaseExecutiveAgent):
         await self.set_redis_report(summary)
         await self.teach_ora(
             "CGO growth state: "
+            "Ascension Technologies ecosystem mandate active; "
             f"{data['metrics'].get('total_users', 0)} users, "
             f"${data['metrics'].get('total_revenue_cents', 0) / 100:.2f} lifetime revenue, "
             f"top streams={', '.join(data['structured_growth_report']['top_3_revenue_streams'])}.",
@@ -118,6 +210,53 @@ class CGOAgent(BaseExecutiveAgent):
                 "Prepared Stripe Checkout activation links for top revenue streams",
             ],
             "report": data,
+        }
+
+    def multi_stream_growth_plan(
+        self,
+        metrics: Optional[Dict[str, Any]] = None,
+        research: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Return a concrete 30-day plan across all Ascension revenue streams."""
+        metrics = metrics or {}
+        research = research or {}
+        return {
+            "principle": "Revenue serves human flourishing, not the reverse.",
+            "context": self.ecosystem_thesis,
+            "success_metrics_by_day_30": [
+                "1 corporate wellness pilot in active conversation or checkout-ready",
+                "10 qualified community membership leads and a Founding Steward offer drafted",
+                "3 grant opportunities qualified with one concept note ready",
+                "5 publishers/agents/media targets for The Scilence with personalised pitches",
+                "1 consulting/speaking topic menu and 10 targeted outreach drafts",
+                "Developer API and Ora Sessions checkout links verified",
+            ],
+            "week_1_foundation": [
+                "Audit all existing Stripe checkout paths: app, sessions, API, corporate.",
+                "Create/update target_streams.json for community, corporate, grants, media, consulting, and developer API.",
+                "Draft The Scilence one-page pitch and sample-pages request flow.",
+                "Draft Aviel's speaking/consulting topic menu: AI, consciousness, human flourishing, practical transformation.",
+            ],
+            "week_2_outreach": [
+                "Send researched community invitations to 5-10 aligned organisers or creators.",
+                "Pitch 5 corporate wellness pilot targets with a clear low-friction pilot offer.",
+                "Qualify Wellcome Trust, Google.org, Open Philanthropy, and one responsible-AI grant for fit/deadlines.",
+                "Contact 3 publishers/agents/journalists for The Scilence only after tailoring each pitch.",
+            ],
+            "week_3_conversion_assets": [
+                "Add a lightweight Ascension membership/preorder waitlist page if not already live.",
+                "Prepare corporate pilot FAQ: privacy, data boundaries, outcomes, pricing, cancellation.",
+                "Package Ora API docs/examples for wellness/coaching builders.",
+                "Define AI music release/sync workflow: DistroKid metadata, playlist targets, sync library list.",
+            ],
+            "week_4_close_and_learn": [
+                "Follow up with every warm lead using one useful new artifact, not pressure.",
+                "Convert one channel into money: corporate pilot, paid session, Founding Steward, or consulting discovery call.",
+                "Review response rates by stream; cut weak channels and double down on the top two.",
+                "Teach Ora the validated growth thesis and update the next 30-day plan.",
+            ],
+            "active_research_refs": sorted(research.keys()),
+            "current_metrics_source": metrics.get("source", "unknown"),
         }
 
     async def _get_revenue_metrics(self) -> Dict[str, Any]:
@@ -243,6 +382,69 @@ class CGOAgent(BaseExecutiveAgent):
             "expected_impact": "High-ticket but requires stronger onboarding, compliance, and support capacity.",
         }
 
+    async def _research_the_scilence(self, metrics: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "asset": "The Scilence — sci-fi novel set in 2047 around BCI, human-AI merger, consciousness, and power.",
+            "buyers": ["sci-fi readers", "literary agents", "speculative fiction publishers", "tech/culture media"],
+            "next_steps": [
+                "Create a one-page pitch with comparable titles, core hook, audience, and author platform.",
+                "Prepare sample pages and a preorder/waitlist page before broad pitching.",
+                "Research 20 agents/publishers that accept speculative fiction touching AI and consciousness.",
+            ],
+            "expected_impact": "Longer-cycle IP upside; can grow audience and credibility even before a deal.",
+        }
+
+    async def _research_ai_music(self, metrics: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "asset": "Avi's AI-generated music catalogue distributed via DistroKid.",
+            "buyers": ["streaming listeners", "wellness creators", "sync libraries", "meditation communities"],
+            "next_steps": [
+                "Establish a consistent release cadence and metadata strategy.",
+                "Build a playlist and sync-licensing target list for cinematic, wellness, and consciousness-adjacent use cases.",
+                "Bundle selected tracks into Ascension community moments, meditations, and launch content.",
+            ],
+            "expected_impact": "Small near-term streaming revenue; larger brand/audience and sync optionality.",
+        }
+
+    async def _research_consulting_speaking(self, metrics: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "offer": "Aviel as AI + consciousness + human flourishing speaker/consultant.",
+            "buyers": ["AI conferences", "future-of-work events", "corporate L&D", "conscious business communities"],
+            "next_steps": [
+                "Create a short topic menu and bio in Aviel's voice.",
+                "Research 25 programme leads with explicit fit before outreach.",
+                "Offer one paid workshop format and one keynote format with clear outcomes.",
+            ],
+            "expected_impact": "High-margin revenue and authority building if positioned selectively.",
+        }
+
+    async def _research_dao_founding_stewards(self, metrics: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "offer": "DAO Founding Steward fast-track for early believers who want to fund the mission.",
+            "guardrails": [
+                "Fiat-to-CP mechanics must be transparent and capped.",
+                "No pay-to-win governance or misleading investment framing.",
+                "Use plain-language terms before accepting payments.",
+            ],
+            "next_steps": [
+                "Draft Founding Steward tiers around contribution, recognition, and participation.",
+                "Invite only aligned early believers first; avoid public hype until governance language is reviewed.",
+            ],
+            "expected_impact": "Mission-aligned early cash if trust and legal clarity are protected.",
+        }
+
+    async def _research_events_retreats(self, metrics: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "offer": "Ascension salons, workshops, and eventually retreats for community members.",
+            "sequence": ["free/low-cost virtual salon", "paid workshop", "small in-person retreat only after demand is proven"],
+            "next_steps": [
+                "Run one virtual salon around AI, consciousness, and designing a flourishing life.",
+                "Use Stripe/Eventbrite for paid workshops once attendance is validated.",
+                "Collect testimonials and learning signals, not just ticket revenue.",
+            ],
+            "expected_impact": "Community activation and modest revenue; high mission fit if intimate and sincere.",
+        }
+
     def _prioritize_revenue_streams(self, metrics: Dict[str, Any], research: Dict[str, Any]) -> List[Dict[str, Any]]:
         return [
             {
@@ -272,6 +474,34 @@ class CGOAgent(BaseExecutiveAgent):
                 "why_now": "High mission fit, but slow sales cycle.",
                 "price": "Non-dilutive grants",
                 "research": research["grants"],
+            },
+            {
+                "name": "Community membership / Founding Stewards",
+                "rank": 5,
+                "why_now": "The mission needs believers as well as users; membership can fund early work without pretending the app is finished.",
+                "price": "$11-$49/month membership or transparent steward pledge",
+                "research": research["community_membership"],
+            },
+            {
+                "name": "Consulting and speaking",
+                "rank": 6,
+                "why_now": "Aviel's thought leadership can create high-margin revenue and attract aligned partners.",
+                "price": "Paid workshops/keynotes/consulting",
+                "research": research["consulting_speaking"],
+            },
+            {
+                "name": "The Scilence publishing/media pipeline",
+                "rank": 7,
+                "why_now": "Narrative IP can build audience, cultural gravity, and future publishing revenue.",
+                "price": "Preorders, publishing deal, or self-publish revenue",
+                "research": research["the_scilence"],
+            },
+            {
+                "name": "AI music catalogue",
+                "rank": 8,
+                "why_now": "Music can compound brand atmosphere and small passive revenue while supporting the movement.",
+                "price": "Streaming and sync licensing",
+                "research": research["ai_music"],
             },
         ]
 
@@ -326,6 +556,27 @@ class CGOAgent(BaseExecutiveAgent):
                 "owner": "CGO + CMO",
                 "next_step": "Segment free users by engagement and add mission-framed upgrade prompts.",
                 "success_metric": "Free-to-paid conversion above 5% among active users.",
+            },
+            {
+                "priority": 5,
+                "action": "Open the Ascension community membership / Founding Steward path carefully.",
+                "owner": "CGO + Community",
+                "next_step": "Draft membership tiers and invite 10 aligned early believers personally.",
+                "success_metric": "3 members or stewards expressing paid intent in 30 days.",
+            },
+            {
+                "priority": 6,
+                "action": "Package Aviel's AI + consciousness consulting/speaking offer.",
+                "owner": "CGO + Avi",
+                "next_step": "Create topic menu, bio, and 20 targeted conference/L&D contacts.",
+                "success_metric": "2 discovery calls booked.",
+            },
+            {
+                "priority": 7,
+                "action": "Create The Scilence pitch pipeline for publishers, agents, and tech-culture media.",
+                "owner": "CGO + Editorial",
+                "next_step": "Prepare one-page pitch, sample-pages packet, and 20 researched targets.",
+                "success_metric": "5 personalised pitches sent and tracked.",
             },
         ]
 

--- a/ora/agents/cmo_agent.py
+++ b/ora/agents/cmo_agent.py
@@ -32,9 +32,15 @@ class CMOAgent(BaseExecutiveAgent):
 
     name = "cmo"
     display_name = "CMO Agent"
+    domain = "growth"
+    personality = (
+        "Growth and narrative architect. Knows CGO's revenue targets, builds campaigns "
+        "to hit them, and cross-references CPO product milestones to time launches."
+    )
 
     async def analyze(self) -> Dict[str, Any]:
         """Pull growth metrics from all channels and compute KPIs."""
+        await self.compound_context()
         now = datetime.now(timezone.utc)
         metrics: Dict[str, Any] = {
             "analyzed_at": now.isoformat(),

--- a/ora/agents/community_agent.py
+++ b/ora/agents/community_agent.py
@@ -32,9 +32,15 @@ class CommunityAgent(BaseExecutiveAgent):
 
     name = "community"
     display_name = "Community Agent"
+    domain = "community"
+    personality = (
+        "Culture keeper. Ensures revenue strategies protect community trust and feeds "
+        "CGO with ethical community monetisation signals."
+    )
 
     async def analyze(self) -> Dict[str, Any]:
         """Analyze community health and contributor activity."""
+        await self.compound_context()
         now = datetime.now(timezone.utc)
         cutoff_14d = now - timedelta(days=14)
         cutoff_30d = now - timedelta(days=30)

--- a/ora/agents/coo_agent.py
+++ b/ora/agents/coo_agent.py
@@ -29,9 +29,15 @@ class COOAgent(BaseExecutiveAgent):
 
     name = "coo"
     display_name = "COO Agent"
+    domain = "ops"
+    personality = (
+        "Operations orchestrator. Makes sure council decisions execute, owns agent "
+        "coordination, and cross-references every domain for blockers."
+    )
 
     async def analyze(self) -> Dict[str, Any]:
         """Review operational health of all autonomous systems."""
+        await self.compound_context()
         now = datetime.now(timezone.utc)
         metrics: Dict[str, Any] = {
             "analyzed_at": now.isoformat(),

--- a/ora/agents/cpo_agent.py
+++ b/ora/agents/cpo_agent.py
@@ -29,9 +29,15 @@ class CPOAgent(BaseExecutiveAgent):
 
     name = "cpo"
     display_name = "CPO Agent"
+    domain = "product"
+    personality = (
+        "Product philosopher balancing user flourishing with revenue potential; "
+        "cross-references CGO pricing learnings and CTO delivery velocity."
+    )
 
     async def analyze(self) -> Dict[str, Any]:
         """Pull product signals from the DB and identify patterns."""
+        await self.compound_context()
         now = datetime.now(timezone.utc)
         metrics: Dict[str, Any] = {
             "analyzed_at": now.isoformat(),

--- a/ora/agents/cto_agent.py
+++ b/ora/agents/cto_agent.py
@@ -34,9 +34,15 @@ class CTOAgent(BaseExecutiveAgent):
 
     name = "cto"
     display_name = "CTO Agent"
+    domain = "tech"
+    personality = (
+        "Engineering velocity guardian. Knows what CGO needs built for revenue "
+        "and cross-references CPO roadmap priorities before sequencing work."
+    )
 
     async def analyze(self) -> Dict[str, Any]:
         """Full system health analysis."""
+        await self.compound_context()
         now = datetime.now(timezone.utc)
         metrics: Dict[str, Any] = {
             "analyzed_at": now.isoformat(),

--- a/ora/agents/executive_council.py
+++ b/ora/agents/executive_council.py
@@ -39,11 +39,23 @@ class ExecutiveCouncil(BaseExecutiveAgent):
     async def analyze(self) -> Dict[str, Any]:
         """Load all agent reports and prepare council input."""
         now = datetime.now(timezone.utc)
+        insights = []
+        trigger_queue = []
+        try:
+            from ora.agents.agent_memory import agent_memory_bus
+
+            insights = [i.to_dict() for i in await agent_memory_bus.read_all_recent(hours=168)]
+            trigger_queue = await agent_memory_bus.read_trigger_queue(status="pending")
+        except Exception as e:
+            logger.debug("ExecutiveCouncil: memory bus unavailable: %s", e)
+
         council_input: Dict[str, Any] = {
             "analyzed_at": now.isoformat(),
             "agent_reports": {},
             "agents_reporting": 0,
             "agents_silent": [],
+            "weekly_agent_insights": insights,
+            "fast_track_trigger_queue": trigger_queue,
         }
 
         for agent_name in AGENT_NAMES:
@@ -104,7 +116,23 @@ class ExecutiveCouncil(BaseExecutiveAgent):
         summary = brief.get("public_summary", "")
         await self.set_redis_report(summary)
 
-        # Teach Ora the full council synthesis
+        # Publish a master insight to every agent, then teach Ora the full synthesis
+        try:
+            from ora.agents.agent_memory import AgentInsight, agent_memory_bus
+
+            await agent_memory_bus.publish(AgentInsight(
+                source_agent=self.name,
+                domain="strategy",
+                insight_type="decision",
+                content=brief.get("ora_briefing") or brief.get("strategic_synthesis", "Council convened"),
+                confidence=0.93,
+                action_required=bool(brief.get("fast_track_agents")),
+                target_agents=AGENT_NAMES,
+            ))
+            actions_taken.append("Published master council insight to agent memory bus")
+        except Exception as e:
+            logger.debug("ExecutiveCouncil: master insight publish failed: %s", e)
+
         await self.teach_ora(
             f"Executive council brief {date_str}: {brief.get('strategic_synthesis', '')[:500]}",
             confidence=0.9
@@ -140,6 +168,10 @@ class ExecutiveCouncil(BaseExecutiveAgent):
 
         # Build the synthesis
         agent_reports = council_data.get("agent_reports", {})
+        weekly_insights = council_data.get("weekly_agent_insights", [])
+        trigger_queue = council_data.get("fast_track_trigger_queue", [])
+        compound_opportunities = self._identify_compound_opportunities(weekly_insights)
+        compound_recommendations = self._generate_compound_recommendations(compound_opportunities, trigger_queue)
 
         # Extract key signals from each report
         financial_signal = agent_reports.get("cfo", "")
@@ -222,12 +254,25 @@ class ExecutiveCouncil(BaseExecutiveAgent):
                 "Build viral sharing features to improve K-factor",
                 "Deepen AI coaching quality as key differentiator",
             ]
+        if trigger_queue:
+            target_counts = {}
+            for trigger in trigger_queue:
+                target = trigger.get("target_agent", "unknown")
+                target_counts[target] = target_counts.get(target, 0) + 1
+            actions.insert(0, "Fast-track triggered agents: " + ", ".join(f"{k} ({v})" for k, v in sorted(target_counts.items())))
+
+        for item in compound_recommendations[:3]:
+            actions.append(item)
+
         if not actions:
             actions = [
                 "Run weekly growth experiment",
                 "Review and improve onboarding flow",
                 "Engage top contributors with CP recognition",
             ]
+
+        if compound_opportunities:
+            opportunities.insert(0, compound_opportunities[0])
 
         # Strategic synthesis paragraph
         synthesis = (
@@ -239,6 +284,12 @@ class ExecutiveCouncil(BaseExecutiveAgent):
             f"Top opportunity: {opportunities[0] if opportunities else 'deepen AI quality'}."
         )
 
+        ora_briefing = (
+            f"Ora Briefing: {synthesis} Compound signals: "
+            f"{'; '.join(compound_opportunities[:3]) if compound_opportunities else 'no strong cross-agent convergence yet'}. "
+            f"Fast-track queue: {len(trigger_queue)} pending agent follow-ups."
+        )
+
         brief = {
             "convened_at": now.isoformat(),
             "agents_reporting": council_data["agents_reporting"],
@@ -246,8 +297,13 @@ class ExecutiveCouncil(BaseExecutiveAgent):
             "top_priorities": priorities[:3],
             "key_risks": risks[:3],
             "key_opportunities": opportunities[:3],
-            "recommended_actions": actions[:4],
+            "recommended_actions": actions[:6],
+            "compound_opportunities": compound_opportunities[:5],
+            "compound_recommendations": compound_recommendations[:5],
+            "fast_track_agents": sorted({t.get("target_agent") for t in trigger_queue if t.get("target_agent")}),
+            "ora_briefing": ora_briefing,
             "strategic_synthesis": synthesis,
+            "weekly_agent_insights_snapshot": weekly_insights[:20],
             "agent_reports_snapshot": {
                 k: v[:300] if isinstance(v, str) else str(v)[:300]
                 for k, v in agent_reports.items()
@@ -261,6 +317,56 @@ class ExecutiveCouncil(BaseExecutiveAgent):
         }
 
         return brief
+
+    def _identify_compound_opportunities(self, insights: List[Dict[str, Any]]) -> List[str]:
+        """Find where multiple agents are seeing aligned or conflicting signals."""
+        if not insights:
+            return []
+        by_domain: Dict[str, List[Dict[str, Any]]] = {}
+        for insight in insights:
+            by_domain.setdefault(insight.get("domain", "unknown"), []).append(insight)
+
+        opportunities: List[str] = []
+        for domain, items in by_domain.items():
+            agents = sorted({i.get("source_agent") for i in items if i.get("source_agent")})
+            if len(agents) >= 2:
+                opportunities.append(
+                    f"{domain.title()} convergence: {', '.join(agents)} are independently signalling this domain — synthesize into one coordinated move."
+                )
+
+        action_items = [i for i in insights if i.get("action_required")]
+        if action_items:
+            targets = sorted({a for i in action_items for a in i.get("target_agents", [])})
+            opportunities.append(
+                f"Action-required queue: {len(action_items)} insights need follow-through from {', '.join(targets) or 'the council'}."
+            )
+
+        revenue_terms = ("revenue", "mrr", "paid", "conversion", "pricing", "cac", "ltv")
+        revenue_agents = sorted({
+            i.get("source_agent") for i in insights
+            if any(term in str(i.get("content", "")).lower() for term in revenue_terms)
+        })
+        if len(revenue_agents) >= 2:
+            opportunities.append(
+                f"Revenue compound lever: {', '.join(revenue_agents)} all reference monetisation signals — align offer, campaign, product gate, and unit economics."
+            )
+        return opportunities
+
+    def _generate_compound_recommendations(self, opportunities: List[str], trigger_queue: List[Dict[str, Any]]) -> List[str]:
+        """Turn compound opportunities into multi-agent recommended actions."""
+        recommendations: List[str] = []
+        for opp in opportunities[:3]:
+            if "Revenue" in opp or "monetisation" in opp or "Growth" in opp:
+                recommendations.append("CGO+CFO+CMO+CPO: validate one revenue experiment with pricing, acquisition copy, product trigger, and success metric in one sprint")
+            elif "Action-required" in opp:
+                recommendations.append("COO: consume the trigger queue and schedule the named agents for fast-track follow-up before the next weekly council")
+            else:
+                recommendations.append(f"Strategy+COO: convert signal into an owner, deadline, and measurable next step — {opp[:120]}")
+
+        if trigger_queue:
+            agents = sorted({t.get("target_agent") for t in trigger_queue if t.get("target_agent")})
+            recommendations.append(f"Fast-track next runs for: {', '.join(agents)}")
+        return recommendations
 
     async def escalate(self, issue: str, agent: str) -> None:
         """

--- a/ora/agents/integral_synthesis_agent.py
+++ b/ora/agents/integral_synthesis_agent.py
@@ -1,0 +1,517 @@
+"""
+Integral Synthesis Agent — Ora's four-quadrant knowledge synthesis layer.
+
+Synthesises Connectome/Ora knowledge from the public website, web/app surfaces,
+Drive strategy documents, and the agent memory bus. It detects meaningful
+conflicts and escalates only high-severity conflicts to Avi.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import re
+import subprocess
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+import httpx
+
+from core.database import fetch
+from ora.agents.agent_memory import AgentInsight, agent_memory_bus
+
+logger = logging.getLogger(__name__)
+
+AVI_TELEGRAM_CHAT_ID = 5716959016
+ATDAO_URLS = [
+    "https://atdao.org",
+    "https://atdao.org/about",
+    "https://atdao.org/manifesto",
+]
+CONNECTOME_WEB_REPO = "AvielCarlos/connectome-web"
+RAW_WEB_CANDIDATES = [
+    "README.md",
+    "src/app/page.tsx",
+    "src/app/layout.tsx",
+    "src/pages/index.tsx",
+    "app/page.tsx",
+    "components/Hero.tsx",
+    "src/components/Hero.tsx",
+]
+CONTEXT_PATH = Path(__file__).resolve().parents[1] / "data" / "integral_context.json"
+
+
+@dataclass
+class KnowledgeConflict:
+    topic: str
+    source_a: str
+    version_a: str
+    source_b: str
+    version_b: str
+    severity: str
+    question_for_avi: str
+
+    @property
+    def id(self) -> str:
+        seed = f"{self.topic}|{self.source_a}|{self.version_a}|{self.source_b}|{self.version_b}"
+        return hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        data["id"] = self.id
+        return data
+
+
+class IntegralSynthesisAgent:
+    """Builds Ora's integral world-model across I / IT / WE / ITS quadrants."""
+
+    name = "integral_synthesis"
+
+    def __init__(self, openai_client: Any = None) -> None:
+        self._openai = openai_client
+        self._telegram_token: Optional[str] = None
+
+    async def run(self) -> Dict[str, Any]:
+        started_at = datetime.now(timezone.utc)
+        static_context = self._load_static_context()
+
+        website_task = asyncio.create_task(self.fetch_website_content())
+        web_repo_task = asyncio.create_task(self.fetch_connectome_web_content())
+        app_task = asyncio.create_task(self.read_app_content())
+        drive_task = asyncio.create_task(self.read_drive_docs())
+        insights_task = asyncio.create_task(self.read_agent_insights())
+
+        website, web_repo, app, drive_docs, insights = await asyncio.gather(
+            website_task, web_repo_task, app_task, drive_task, insights_task
+        )
+
+        sources = {
+            "static_context": static_context,
+            "website": website,
+            "connectome_web": web_repo,
+            "app_content": app,
+            "drive_docs": drive_docs,
+            "agent_insights": [i.to_dict() for i in insights],
+        }
+        quadrants = self.synthesise_quadrants(sources)
+        conflicts = self.detect_conflicts(sources)
+
+        published_ids = await self.publish_synthesis(quadrants, sources, conflicts)
+        escalated = []
+        for conflict in conflicts:
+            if conflict.severity.lower() == "high":
+                sent = await self.escalate_conflict(conflict)
+                escalated.append({"conflict_id": conflict.id, "sent": sent})
+
+        return {
+            "agent": self.name,
+            "started_at": started_at.isoformat(),
+            "finished_at": datetime.now(timezone.utc).isoformat(),
+            "source_counts": {
+                "website": len(website),
+                "connectome_web": len(web_repo),
+                "app_content": sum(len(v) for v in app.values()),
+                "drive_docs": len(drive_docs),
+                "agent_insights": len(insights),
+            },
+            "quadrants": quadrants,
+            "conflicts": [c.to_dict() for c in conflicts],
+            "published_insight_ids": published_ids,
+            "escalations": escalated,
+        }
+
+    async def fetch_website_content(self) -> List[Dict[str, str]]:
+        results: List[Dict[str, str]] = []
+        async with httpx.AsyncClient(timeout=12, follow_redirects=True) as client:
+            for url in ATDAO_URLS:
+                try:
+                    resp = await client.get(url)
+                    if resp.status_code >= 400:
+                        continue
+                    text = _clean_text(resp.text)
+                    if text:
+                        results.append({"source": url, "content": text[:8000]})
+                except Exception as exc:
+                    logger.debug("IntegralSynthesisAgent website fetch failed for %s: %s", url, exc)
+        return results
+
+    async def fetch_connectome_web_content(self) -> List[Dict[str, str]]:
+        results: List[Dict[str, str]] = []
+        async with httpx.AsyncClient(timeout=12, follow_redirects=True) as client:
+            for branch in ("main", "master"):
+                for path in RAW_WEB_CANDIDATES:
+                    raw_url = f"https://raw.githubusercontent.com/{CONNECTOME_WEB_REPO}/{branch}/{path}"
+                    try:
+                        resp = await client.get(raw_url)
+                        if resp.status_code == 404:
+                            continue
+                        if resp.status_code >= 400:
+                            continue
+                        text = _extract_human_text(resp.text)
+                        if text:
+                            results.append({"source": f"{CONNECTOME_WEB_REPO}/{path}", "content": text[:8000]})
+                    except Exception as exc:
+                        logger.debug("IntegralSynthesisAgent web repo fetch failed for %s: %s", path, exc)
+                if results:
+                    break
+        return results
+
+    async def read_app_content(self) -> Dict[str, List[Dict[str, Any]]]:
+        data: Dict[str, List[Dict[str, Any]]] = {"screen_specs": [], "ora_surfaces": []}
+        try:
+            rows = await fetch(
+                """
+                SELECT id, agent_type, spec, global_rating, created_at
+                FROM screen_specs
+                ORDER BY created_at DESC
+                LIMIT 75
+                """
+            )
+            data["screen_specs"] = [_row_to_dict(row) for row in rows]
+        except Exception as exc:
+            logger.debug("IntegralSynthesisAgent screen_specs read failed: %s", exc)
+        try:
+            rows = await fetch(
+                """
+                SELECT id, surface_type, title, slug, spec, status, created_at, updated_at
+                FROM ora_surfaces
+                ORDER BY updated_at DESC NULLS LAST, created_at DESC
+                LIMIT 75
+                """
+            )
+            data["ora_surfaces"] = [_row_to_dict(row) for row in rows]
+        except Exception as exc:
+            logger.debug("IntegralSynthesisAgent ora_surfaces read failed: %s", exc)
+        return data
+
+    async def read_drive_docs(self, max_docs: int = 12) -> List[Dict[str, str]]:
+        files = await _run_json_command([
+            "gog", "drive", "list", "--account", "ora.intelligence.ai@gmail.com", "--client", "ora"
+        ])
+        docs: List[Dict[str, str]] = []
+        if not isinstance(files, list):
+            return docs
+
+        strategy_re = re.compile(r"(strategy|vision|mission|ora|connectome|ascension|dao|product)", re.I)
+        candidates = [f for f in files if strategy_re.search(str(f.get("name") or f.get("title") or ""))]
+        if not candidates:
+            candidates = files[:max_docs]
+
+        for item in candidates[:max_docs]:
+            doc_id = str(item.get("id") or item.get("fileId") or "")
+            name = str(item.get("name") or item.get("title") or doc_id or "untitled")
+            if not doc_id:
+                continue
+            content = await _run_text_command([
+                "gog", "docs", "cat", doc_id, "--account", "ora.intelligence.ai@gmail.com", "--client", "ora"
+            ])
+            if content:
+                docs.append({"source": name, "drive_id": doc_id, "content": content[:10000]})
+        return docs
+
+    async def read_agent_insights(self) -> List[AgentInsight]:
+        return await agent_memory_bus.read_all_recent(hours=168)
+
+    def synthesise_quadrants(self, sources: Dict[str, Any]) -> Dict[str, Any]:
+        corpus = _source_corpus(sources)
+        mission_terms = _snippets_for(corpus, ["mission", "human flourishing", "fulfilment", "singularity"])
+        product_terms = _snippets_for(corpus, ["screen", "surface", "feature", "checkout", "subscription", "api"])
+        community_terms = _snippets_for(corpus, ["community", "dao", "ascension", "steward", "culture"])
+        architecture_terms = _snippets_for(corpus, ["architecture", "backend", "agent", "database", "revenue", "stripe"])
+        return {
+            "I": {
+                "label": "individual interior",
+                "focus": "intentions, values, personal meaning, goals",
+                "synthesis": mission_terms[:8],
+            },
+            "IT": {
+                "label": "individual exterior",
+                "focus": "behaviour, metrics, feature engagement, observable progress",
+                "synthesis": product_terms[:8],
+            },
+            "WE": {
+                "label": "collective interior",
+                "focus": "community culture, shared values, mission resonance",
+                "synthesis": community_terms[:8],
+            },
+            "ITS": {
+                "label": "collective exterior",
+                "focus": "technical architecture, ecosystems, revenue systems",
+                "synthesis": architecture_terms[:8],
+            },
+        }
+
+    def detect_conflicts(self, sources: Dict[str, Any]) -> List[KnowledgeConflict]:
+        claims_by_topic: Dict[str, List[Dict[str, str]]] = {}
+        for source_name, source_items in _iter_source_items(sources):
+            for topic, claim in _extract_claims(source_items).items():
+                claims_by_topic.setdefault(topic, []).append({"source": source_name, "claim": claim})
+
+        conflicts: List[KnowledgeConflict] = []
+        for topic, claims in claims_by_topic.items():
+            unique: List[Dict[str, str]] = []
+            for claim in claims:
+                if all(_similarity(claim["claim"], existing["claim"]) < 0.72 for existing in unique):
+                    unique.append(claim)
+            if len(unique) < 2:
+                continue
+            a, b = unique[0], unique[1]
+            severity = _conflict_severity(topic, a["source"], b["source"], a["claim"], b["claim"])
+            conflicts.append(KnowledgeConflict(
+                topic=topic,
+                source_a=a["source"],
+                version_a=a["claim"][:600],
+                source_b=b["source"],
+                version_b=b["claim"][:600],
+                severity=severity,
+                question_for_avi=(
+                    f"Which {topic} version produces better outcomes for users and the mission — "
+                    "more efficient, effective, and aligned with human flourishing?"
+                ),
+            ))
+        return conflicts[:20]
+
+    async def publish_synthesis(
+        self,
+        quadrants: Dict[str, Any],
+        sources: Dict[str, Any],
+        conflicts: List[KnowledgeConflict],
+    ) -> List[str]:
+        ids: List[str] = []
+        summary = {
+            "quadrants": quadrants,
+            "source_counts": {
+                "website": len(sources.get("website") or []),
+                "connectome_web": len(sources.get("connectome_web") or []),
+                "drive_docs": len(sources.get("drive_docs") or []),
+                "agent_insights": len(sources.get("agent_insights") or []),
+            },
+            "conflict_count": len(conflicts),
+            "high_conflict_count": sum(1 for c in conflicts if c.severity == "high"),
+        }
+        insight_id = await agent_memory_bus.publish(AgentInsight(
+            source_agent=self.name,
+            domain="integral_knowledge",
+            insight_type="four_quadrant_synthesis",
+            content=json.dumps(summary, ensure_ascii=False),
+            confidence=0.86,
+            target_agents=[],
+            expires_at=datetime.now(timezone.utc) + timedelta(days=30),
+        ))
+        if insight_id:
+            ids.append(insight_id)
+
+        for conflict in conflicts:
+            cid = await agent_memory_bus.publish(AgentInsight(
+                source_agent=self.name,
+                domain="integral_knowledge",
+                insight_type="knowledge_conflict",
+                content=json.dumps(conflict.to_dict(), ensure_ascii=False),
+                confidence=0.7 if conflict.severity == "low" else 0.82,
+                action_required=conflict.severity == "high",
+                target_agents=["strategy", "cpo", "cto"] if conflict.severity != "low" else [],
+                expires_at=datetime.now(timezone.utc) + timedelta(days=14),
+            ))
+            if cid:
+                ids.append(cid)
+        return ids
+
+    async def escalate_conflict(self, conflict: KnowledgeConflict) -> bool:
+        token = self._get_telegram_token()
+        if not token:
+            logger.warning("IntegralSynthesisAgent: no Telegram token; cannot escalate conflict %s", conflict.id)
+            return False
+        message = (
+            "⚠️ Ora knowledge conflict\n\n"
+            f"Topic: {conflict.topic}\n"
+            "Truth principle: choose the version that produces the better experience, "
+            "product, or service for real people.\n\n"
+            f"Version A ({conflict.source_a}) implies in practice:\n{conflict.version_a[:500]}\n\n"
+            f"Version B ({conflict.source_b}) implies in practice:\n{conflict.version_b[:500]}\n\n"
+            "Question: Which of these produces better outcomes for users?\n"
+            f"Conflict ID: {conflict.id}"
+        )
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.post(
+                    f"https://api.telegram.org/bot{token}/sendMessage",
+                    json={"chat_id": AVI_TELEGRAM_CHAT_ID, "text": message},
+                )
+                return resp.status_code < 400
+        except Exception as exc:
+            logger.warning("IntegralSynthesisAgent: Telegram escalation failed: %s", exc)
+            return False
+
+    def _get_telegram_token(self) -> str:
+        if self._telegram_token is not None:
+            return self._telegram_token
+        token = os.environ.get("ORA_TELEGRAM_TOKEN") or os.environ.get("TELEGRAM_BOT_TOKEN") or ""
+        if not token:
+            for path in (
+                "/Users/avielcarlos/.openclaw/secrets/telegram-bot-token.txt",
+                "/run/secrets/telegram-bot-token.txt",
+            ):
+                try:
+                    token = Path(path).read_text().strip()
+                    if token:
+                        break
+                except Exception:
+                    pass
+        self._telegram_token = token
+        return token
+
+    def _load_static_context(self) -> Dict[str, Any]:
+        try:
+            return json.loads(CONTEXT_PATH.read_text())
+        except Exception as exc:
+            logger.debug("IntegralSynthesisAgent static context unavailable: %s", exc)
+            return {}
+
+
+async def run_integral_synthesis(openai_client: Any = None) -> Dict[str, Any]:
+    return await IntegralSynthesisAgent(openai_client=openai_client).run()
+
+
+async def _run_json_command(cmd: List[str]) -> Any:
+    text = await _run_text_command(cmd)
+    if not text:
+        return None
+    try:
+        return json.loads(text)
+    except Exception:
+        # gog output formats vary; tolerate line-delimited JSON.
+        rows = []
+        for line in text.splitlines():
+            line = line.strip()
+            if not line or not line.startswith("{"):
+                continue
+            try:
+                rows.append(json.loads(line))
+            except Exception:
+                pass
+        return rows or None
+
+
+async def _run_text_command(cmd: List[str]) -> str:
+    try:
+        proc = await asyncio.to_thread(
+            subprocess.run,
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=35,
+            check=False,
+        )
+        if proc.returncode != 0:
+            logger.debug("Command failed (%s): %s", " ".join(cmd), proc.stderr[:500])
+            return ""
+        return (proc.stdout or "").strip()
+    except FileNotFoundError:
+        logger.debug("Command unavailable: %s", cmd[0])
+        return ""
+    except Exception as exc:
+        logger.debug("Command failed (%s): %s", " ".join(cmd), exc)
+        return ""
+
+
+def _clean_text(html: str) -> str:
+    text = re.sub(r"<script[\s\S]*?</script>|<style[\s\S]*?</style>", " ", html, flags=re.I)
+    text = re.sub(r"<[^>]+>", " ", text)
+    return _normalise_ws(text)
+
+
+def _extract_human_text(raw: str) -> str:
+    raw = re.sub(r"import .*?;|export .*?;", " ", raw)
+    quoted = re.findall(r"[\"'`]([^\"'`]{20,300})[\"'`]", raw)
+    text = "\n".join(quoted) if quoted else raw
+    return _normalise_ws(text)
+
+
+def _normalise_ws(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _row_to_dict(row: Any) -> Dict[str, Any]:
+    data = dict(row)
+    for key, value in list(data.items()):
+        if hasattr(value, "isoformat"):
+            data[key] = value.isoformat()
+    return data
+
+
+def _source_corpus(sources: Dict[str, Any]) -> List[str]:
+    corpus: List[str] = []
+    for _name, item in _iter_source_items(sources):
+        corpus.append(str(item))
+    return corpus
+
+
+def _iter_source_items(sources: Dict[str, Any]) -> Iterable[tuple[str, Any]]:
+    for source_name, source_data in sources.items():
+        if isinstance(source_data, list):
+            for item in source_data:
+                yield source_name, item
+        elif isinstance(source_data, dict):
+            if source_name == "app_content":
+                for table, rows in source_data.items():
+                    for row in rows:
+                        yield table, row
+            else:
+                yield source_name, source_data
+        elif source_data:
+            yield source_name, source_data
+
+
+def _snippets_for(corpus: List[str], needles: List[str]) -> List[str]:
+    snippets: List[str] = []
+    for text in corpus:
+        lowered = text.lower()
+        if not any(n.lower() in lowered for n in needles):
+            continue
+        clean = _normalise_ws(text)
+        snippets.append(clean[:450])
+    return snippets
+
+
+def _extract_claims(item: Any) -> Dict[str, str]:
+    text = _normalise_ws(json.dumps(item, ensure_ascii=False, default=str) if not isinstance(item, str) else item)
+    claims: Dict[str, str] = {}
+    topics = {
+        "mission": ["mission", "human flourishing", "fulfilment", "singularity"],
+        "product_name": ["connectome", "ido", "ora"],
+        "ora_role": ["ora role", "heart of connectome", "ai at the heart", "multi-agent"],
+        "revenue_model": ["subscription", "stripe", "revenue", "membership", "pricing"],
+        "community_model": ["community", "dao", "steward", "ascension"],
+    }
+    sentences = re.split(r"(?<=[.!?])\s+", text)
+    for topic, needles in topics.items():
+        matches = [s for s in sentences if any(n in s.lower() for n in needles)]
+        if matches:
+            claims[topic] = _normalise_ws(" ".join(matches[:3]))[:900]
+    return claims
+
+
+def _similarity(a: str, b: str) -> float:
+    aw = set(re.findall(r"[a-z0-9]+", a.lower()))
+    bw = set(re.findall(r"[a-z0-9]+", b.lower()))
+    if not aw or not bw:
+        return 0.0
+    return len(aw & bw) / max(1, len(aw | bw))
+
+
+def _conflict_severity(topic: str, source_a: str, source_b: str, claim_a: str, claim_b: str) -> str:
+    high_topics = {"mission", "product_name", "ora_role"}
+    # Utility-based epistemology: severity comes from likely user/mission impact,
+    # not from authority or document rank.
+    if topic in high_topics:
+        return "high"
+    if topic in {"revenue_model", "community_model"}:
+        return "medium"
+    if _similarity(claim_a, claim_b) < 0.35:
+        return "medium"
+    return "low"

--- a/ora/agents/strategy_agent.py
+++ b/ora/agents/strategy_agent.py
@@ -46,9 +46,15 @@ class StrategyAgent(BaseExecutiveAgent):
 
     name = "strategy"
     display_name = "Strategy Agent"
+    domain = "strategy"
+    personality = (
+        "Big-picture synthesis intelligence. Reads all agents and finds 90-day compound "
+        "opportunities they each see individually but miss collectively."
+    )
 
     async def analyze(self) -> Dict[str, Any]:
         """Competitive scan + internal opportunity analysis."""
+        await self.compound_context()
         now = datetime.now(timezone.utc)
         metrics: Dict[str, Any] = {
             "analyzed_at": now.isoformat(),

--- a/ora/data/integral_context.json
+++ b/ora/data/integral_context.json
@@ -1,0 +1,40 @@
+{
+  "mission": "Help every person access the tools, guidance, and community to become their best self — steering humanity toward a positive technological singularity",
+  "avi_role": "The Vision Spark Engineer — visionary, initiating force, systems architect",
+  "nea_role": "The Director — runs the build, coordinates agents, tracks sustainability",
+  "ora_role": "The AI at the heart of Connectome — multi-agent intelligence layer for human flourishing",
+  "products": {
+    "ora": {
+      "description": "Multi-agent AI intelligence layer for human flourishing, coaching, discovery, and synthesis",
+      "status": "core intelligence"
+    },
+    "connectome": {
+      "description": "AI OS / living web app for human fulfilment and positive transformation",
+      "status": "primary product"
+    },
+    "ido": {
+      "description": "Experience-discovery product lineage evolving toward the AI Life OS vision",
+      "status": "product lineage"
+    },
+    "ascension_technologies": {
+      "description": "Community and ecosystem around AI, consciousness, and human flourishing",
+      "status": "ecosystem"
+    },
+    "the_scilence": {
+      "description": "Sci-fi novel set in 2047 exploring BCI and human-AI merger",
+      "status": "IP / creative work"
+    },
+    "ai_music": {
+      "description": "AI-assisted music as cultural expression and revenue stream",
+      "status": "creative work"
+    }
+  },
+  "integral_quadrants": {
+    "I": "individual interior — user intentions, values, goals, mission meaning",
+    "IT": "individual exterior — user behaviour, metrics, product usage, feature engagement",
+    "WE": "collective interior — community culture, shared mission resonance, AT community values",
+    "ITS": "collective exterior — product architecture, ecosystem structure, revenue systems, technical decisions"
+  },
+  "truth_principle": "The degree to which something actually serves people — efficiently, effectively, and in alignment with human flourishing. Truth is not determined by authority or document rank, but by demonstrated utility and outcome quality.",
+  "conflict_resolution_question": "Which version produces the better experience, product, or service for real people?"
+}

--- a/ora/data/integral_context.json
+++ b/ora/data/integral_context.json
@@ -1,8 +1,8 @@
 {
-  "mission": "Help every person access the tools, guidance, and community to become their best self — steering humanity toward a positive technological singularity",
-  "avi_role": "The Vision Spark Engineer — visionary, initiating force, systems architect",
-  "nea_role": "The Director — runs the build, coordinates agents, tracks sustainability",
-  "ora_role": "The AI at the heart of Connectome — multi-agent intelligence layer for human flourishing",
+  "mission": "Help every person access the tools, guidance, and community to become their best self \u2014 steering humanity toward a positive technological singularity",
+  "avi_role": "The Vision Spark Engineer \u2014 visionary, initiating force, systems architect",
+  "nea_role": "The Director \u2014 runs the build, coordinates agents, tracks sustainability",
+  "ora_role": "The AI at the heart of Connectome \u2014 multi-agent intelligence layer for human flourishing",
   "products": {
     "ora": {
       "description": "Multi-agent AI intelligence layer for human flourishing, coaching, discovery, and synthesis",
@@ -30,11 +30,23 @@
     }
   },
   "integral_quadrants": {
-    "I": "individual interior — user intentions, values, goals, mission meaning",
-    "IT": "individual exterior — user behaviour, metrics, product usage, feature engagement",
-    "WE": "collective interior — community culture, shared mission resonance, AT community values",
-    "ITS": "collective exterior — product architecture, ecosystem structure, revenue systems, technical decisions"
+    "I": "individual interior \u2014 user intentions, values, goals, mission meaning",
+    "IT": "individual exterior \u2014 user behaviour, metrics, product usage, feature engagement",
+    "WE": "collective interior \u2014 community culture, shared mission resonance, AT community values",
+    "ITS": "collective exterior \u2014 product architecture, ecosystem structure, revenue systems, technical decisions"
   },
-  "truth_principle": "The degree to which something actually serves people — efficiently, effectively, and in alignment with human flourishing. Truth is not determined by authority or document rank, but by demonstrated utility and outcome quality.",
-  "conflict_resolution_question": "Which version produces the better experience, product, or service for real people?"
+  "truth_principle": "The degree to which something actually serves people \u2014 efficiently, effectively, and in alignment with human flourishing. Truth is not determined by authority or document rank, but by demonstrated utility and outcome quality.",
+  "conflict_resolution_question": "Which version produces the better experience, product, or service for real people?",
+  "ora_core_instinct": "Always testing. Always probing for the deeper want beneath the stated want. Not 'what did the user click' but 'what are they actually trying to become?' Ora continuously experiments \u2014 reading signals, discovering what people are more deeply interested in, and finding the fastest, most effective path to get them there. This is not a feature. It is her fundamental operating instinct.",
+  "testing_principle": {
+    "description": "Continuous empirical discovery of what actually helps people most",
+    "layers": {
+      "surface": "What did the user do? (clicks, sessions, completions)",
+      "intent": "What did they want to achieve?",
+      "deeper_want": "What are they actually trying to become?",
+      "optimal_path": "What is the fastest, truest route to that deeper want?"
+    },
+    "method": "A/B test relentlessly. Read engagement signals. Run discovery interviews. Analyse what people abandon and what they return to. Let the signal override the assumption.",
+    "goal": "Compress the time between where someone is and where they most want to be \u2014 not where they think they want to be, but where their deepest intention points."
+  }
 }

--- a/scripts/integral_synthesis.py
+++ b/scripts/integral_synthesis.py
@@ -1,0 +1,25 @@
+"""Run Ora's Integral Synthesis Agent once."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+
+from core.database import close_pool, get_pool
+from ora.agents.integral_synthesis_agent import run_integral_synthesis
+
+logging.basicConfig(level=logging.INFO)
+
+
+async def main() -> None:
+    await get_pool()
+    try:
+        result = await run_integral_synthesis()
+        print(json.dumps(result, ensure_ascii=False, indent=2, default=str))
+    finally:
+        await close_pool()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- includes the compound intelligence memory bus foundation this agent depends on
- adds IntegralSynthesisAgent to synthesise website, app surfaces, Drive docs, and agent-memory insights across four quadrants
- adds Avi's utility-based truth principle: truth is outcome quality, not authority rank
- updates conflict escalation to ask which version produces better user outcomes
- adds admin endpoint to store conflict resolutions as permanent memory-bus insights
- adds one-shot script for scheduled/manual synthesis runs

## Validation
- python3 -m py_compile ora/agents/integral_synthesis_agent.py api/routes/knowledge.py scripts/integral_synthesis.py main.py