### PR TITLE
feat: add IOO vector pathfinding and enrichment

### DIFF
--- a/api/routes/gamification.py
+++ b/api/routes/gamification.py
@@ -40,6 +40,7 @@ XP_TABLE = {
     "goal_create":    50,
     "goal_step":      40,
     "goal_complete": 200,
+    "ioo_node_complete": 100,
     "journal_entry":  25,
     "chat_message":   10,
     "collection_create": 15,

--- a/api/routes/ioo.py
+++ b/api/routes/ioo.py
@@ -25,11 +25,32 @@ from pydantic import BaseModel
 from core.database import fetch, fetchrow, fetchval, execute
 from api.middleware import get_current_user_id
 from ora.agents.ioo_graph_agent import get_graph_agent
+from ora.agents.ioo_enrichment_agent import get_ioo_enrichment_agent
 from ora.agents.surface_generator import SurfaceGenerator
 from ora.agents.surface_lifecycle import SurfaceLifecycleManager
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/ioo", tags=["ioo"])
+
+
+async def _ioo_xp_for_node(node_id: str, user_id: str) -> int:
+    """Calculate XP for completing an IOO node, scaled by difficulty."""
+    node = await fetchrow(
+        "SELECT difficulty_level, type, goal_category, step_type FROM ioo_nodes WHERE id = $1::uuid",
+        str(node_id),
+    )
+    if not node:
+        return 0
+
+    difficulty = int(node["difficulty_level"] or 5)
+    xp_by_difficulty = {
+        1: 25, 2: 40, 3: 60, 4: 80, 5: 100,
+        6: 150, 7: 200, 8: 300, 9: 400, 10: 500,
+    }
+    base_xp = xp_by_difficulty.get(difficulty, 100)
+    if (node["step_type"] or "digital") == "physical":
+        base_xp = int(base_xp * 1.5)
+    return base_xp
 
 
 # ---------------------------------------------------------------------------
@@ -164,9 +185,16 @@ async def update_user_state(
 async def get_graph_recommendations(
     goal_id: Optional[str] = Query(None),
     limit: int = Query(5, ge=1, le=20),
+    preference: str = Query("mixed", pattern="^(prefer_digital|prefer_physical|mixed)$"),
     user_id: str = Depends(get_current_user_id),
 ):
     """Return recommended next nodes toward a goal, filtered by user capabilities."""
+    if goal_id:
+        try:
+            UUID(goal_id)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid goal node ID")
+
     agent = get_graph_agent()
     try:
         nodes = await agent.recommend_next_nodes(
@@ -174,11 +202,103 @@ async def get_graph_recommendations(
             goal_id=goal_id,
             limit=limit,
         )
+        suggested_path = []
+        if goal_id:
+            suggested_path = await agent.build_personalised_path(
+                user_id=str(user_id),
+                goal_node_id=goal_id,
+                max_steps=10,
+                preference=preference,
+            )
     except Exception as e:
         logger.error(f"Graph recommendation error: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Graph recommendation failed")
 
-    return {"nodes": nodes, "count": len(nodes)}
+    return {"nodes": nodes, "count": len(nodes), "preference": preference, "suggested_path": suggested_path}
+
+
+@router.get("/path")
+async def get_path_to_goal(
+    goal_id: str = Query(..., description="Destination IOO goal node ID"),
+    max_steps: int = Query(10, ge=1, le=25),
+    preference: str = Query("mixed", pattern="^(prefer_digital|prefer_physical|mixed)$"),
+    user_id: str = Depends(get_current_user_id),
+):
+    """Return Google-Maps-style step-by-step path to a goal node."""
+    try:
+        UUID(goal_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid goal node ID")
+
+    agent = get_graph_agent()
+    try:
+        path = await agent.build_personalised_path(
+            user_id=str(user_id),
+            goal_node_id=goal_id,
+            max_steps=max_steps,
+            preference=preference,
+        )
+    except Exception as e:
+        logger.error(f"IOO pathfinding error: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Pathfinding failed")
+    if not path:
+        goal_exists = await fetchval(
+            "SELECT EXISTS(SELECT 1 FROM ioo_nodes WHERE id = $1::uuid AND is_active = TRUE)",
+            goal_id,
+        )
+        if not goal_exists:
+            raise HTTPException(status_code=404, detail="Goal node not found")
+    return {"goal_id": goal_id, "preference": preference, "path": path, "steps": len(path)}
+
+
+@router.get("/eligibility/{node_id}")
+async def get_node_eligibility(
+    node_id: str,
+    user_id: str = Depends(get_current_user_id),
+):
+    """Check whether current user can attempt a node and which bridge nodes they need."""
+    try:
+        UUID(node_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid node ID")
+    agent = get_graph_agent()
+    result = await agent.check_node_eligibility(str(user_id), node_id)
+    if result.get("gaps") and result["gaps"][0].get("type") == "missing_node":
+        raise HTTPException(status_code=404, detail="Node not found")
+    return result
+
+
+@router.get("/vector")
+async def get_my_ioo_vector_summary(user_id: str = Depends(get_current_user_id)):
+    """Return a safe summary of the current user's IOO vector fingerprint."""
+    agent = get_graph_agent()
+    return await agent.get_user_vector_summary(str(user_id))
+
+
+@router.get("/vector-recommend")
+async def get_vector_recommendations(
+    goal_context: str = Query(..., min_length=1),
+    limit: int = Query(10, ge=1, le=50),
+    preference: str = Query("mixed", pattern="^(prefer_digital|prefer_physical|mixed)$"),
+    user_id: str = Depends(get_current_user_id),
+):
+    """Return IOO nodes ranked by semantic similarity to a goal/context string."""
+    agent = get_graph_agent()
+    nodes = await agent.vector_recommend(
+        str(user_id),
+        goal_context=goal_context,
+        limit=limit,
+        preference=preference,
+    )
+    return {"nodes": nodes, "count": len(nodes), "preference": preference}
+
+
+@router.post("/embed-nodes")
+async def embed_ioo_nodes(user_id: str = Depends(get_current_user_id)):
+    """Embed IOO nodes that do not have embeddings yet. Available to all for Phase 1."""
+    agent = get_graph_agent()
+    embedded = await agent.embed_all_nodes()
+    return {"ok": True, "embedded": embedded}
 
 
 # ---------------------------------------------------------------------------
@@ -259,12 +379,27 @@ async def record_progress(
             success=True,
             hours_taken=body.hours_taken or 0.0,
         )
+        xp_amount = await _ioo_xp_for_node(str(body.node_id), str(user_id))
+        if xp_amount > 0:
+            try:
+                await execute(
+                    "INSERT INTO xp_log (user_id, amount, reason, ref_id) VALUES ($1, $2, $3, $4)",
+                    UUID(str(user_id)), xp_amount, "ioo_node_complete", str(body.node_id),
+                )
+            except Exception as e:
+                logger.warning(f"IOO XP award failed: {e}")
     elif body.status == "abandoned":
         await agent.record_node_outcome(
             str(user_id),
             str(body.node_id),
             success=False,
         )
+
+    if body.status in ("viewed", "started", "completed"):
+        try:
+            await agent.build_user_ioo_vector(str(user_id))
+        except Exception as e:
+            logger.debug(f"IOO user vector update skipped: {e}")
 
     return {"ok": True, "status": body.status}
 
@@ -302,6 +437,84 @@ async def get_progress(
         *params,
     )
     return {"progress": [dict(r) for r in rows]}
+
+
+
+
+# ---------------------------------------------------------------------------
+# Proposals / Enrichment
+# ---------------------------------------------------------------------------
+
+@router.get("/proposals")
+async def list_node_proposals(
+    status: str = Query("pending", pattern="^(pending|approved|rejected|all)$"),
+    limit: int = Query(50, ge=1, le=200),
+    user_id: str = Depends(get_current_user_id),
+):
+    """Return IOO node proposals for review. Admin-light for Phase 1."""
+    if status == "all":
+        rows = await fetch(
+            "SELECT * FROM ioo_node_proposals ORDER BY created_at DESC LIMIT $1",
+            limit,
+        )
+    else:
+        rows = await fetch(
+            "SELECT * FROM ioo_node_proposals WHERE status = $1 ORDER BY created_at DESC LIMIT $2",
+            status, limit,
+        )
+    return {"proposals": [dict(r) for r in rows], "count": len(rows)}
+
+
+@router.post("/proposals/{proposal_id}/approve")
+async def approve_node_proposal(
+    proposal_id: str,
+    user_id: str = Depends(get_current_user_id),
+):
+    """Promote a pending proposal into a live IOO node."""
+    try:
+        UUID(proposal_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid proposal ID")
+
+    proposal = await fetchrow("SELECT * FROM ioo_node_proposals WHERE id = $1::uuid", proposal_id)
+    if not proposal:
+        raise HTTPException(status_code=404, detail="Proposal not found")
+
+    existing = await fetchrow(
+        "SELECT id FROM ioo_nodes WHERE lower(title) = lower($1) LIMIT 1",
+        proposal["title"],
+    )
+    if existing:
+        await execute("UPDATE ioo_node_proposals SET status = 'approved' WHERE id = $1::uuid", proposal_id)
+        return {"ok": True, "node_id": str(existing["id"]), "already_exists": True}
+
+    node = await fetchrow(
+        """
+        INSERT INTO ioo_nodes
+            (type, title, description, tags, domain, step_type, goal_category, difficulty_level)
+        VALUES ('activity', $1, $2, $3, $4, $5, $6, 5)
+        RETURNING id
+        """,
+        proposal["title"],
+        proposal["description"],
+        proposal["tags"] or [],
+        proposal["domain"],
+        proposal["step_type"] or "hybrid",
+        proposal["goal_category"],
+    )
+    await execute("UPDATE ioo_node_proposals SET status = 'approved' WHERE id = $1::uuid", proposal_id)
+    try:
+        await get_graph_agent().embed_all_nodes()
+    except Exception as e:
+        logger.debug(f"Embedding approved IOO proposal skipped: {e}")
+    return {"ok": True, "node_id": str(node["id"])}
+
+
+@router.post("/enrich")
+async def run_ioo_enrichment(user_id: str = Depends(get_current_user_id)):
+    """Run daily IOO graph enrichment now. Admin-light for Phase 1."""
+    result = await get_ioo_enrichment_agent().run_daily()
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/core/database.py
+++ b/core/database.py
@@ -1413,6 +1413,14 @@ async def run_migrations():
                 requires_skills TEXT[] DEFAULT '{}',
                 requires_location TEXT,
                 requires_time_hours NUMERIC(5,1),
+                step_type TEXT DEFAULT 'hybrid'
+                    CHECK (step_type IN ('digital','physical','hybrid')),
+                physical_context TEXT,
+                best_time TEXT,
+                requirements JSONB DEFAULT '{}',
+                prerequisite_nodes UUID[] DEFAULT '{}',
+                estimated_duration_days INTEGER,
+                difficulty_level INTEGER DEFAULT 5,
                 attempt_count INT DEFAULT 0,
                 success_count INT DEFAULT 0,
                 avg_completion_hours NUMERIC(8,2),
@@ -1430,6 +1438,60 @@ async def run_migrations():
         await conn.execute("""
             CREATE INDEX IF NOT EXISTS idx_ioo_nodes_active ON ioo_nodes(is_active)
         """)
+        await conn.execute("""
+            ALTER TABLE ioo_nodes ADD COLUMN IF NOT EXISTS embedding vector(1536)
+        """)
+        await conn.execute("""
+            ALTER TABLE ioo_nodes ADD COLUMN IF NOT EXISTS goal_category TEXT
+        """)
+        await conn.execute("""
+            ALTER TABLE ioo_nodes ADD COLUMN IF NOT EXISTS step_type TEXT DEFAULT 'hybrid'
+        """)
+        await conn.execute("""
+            ALTER TABLE ioo_nodes ADD COLUMN IF NOT EXISTS physical_context TEXT
+        """)
+        await conn.execute("""
+            ALTER TABLE ioo_nodes ADD COLUMN IF NOT EXISTS best_time TEXT
+        """)
+        await conn.execute("""
+            ALTER TABLE ioo_nodes ADD COLUMN IF NOT EXISTS requirements JSONB DEFAULT '{}'
+        """)
+        await conn.execute("""
+            ALTER TABLE ioo_nodes ADD COLUMN IF NOT EXISTS prerequisite_nodes UUID[] DEFAULT '{}'
+        """)
+        await conn.execute("""
+            ALTER TABLE ioo_nodes ADD COLUMN IF NOT EXISTS estimated_duration_days INTEGER
+        """)
+        await conn.execute("""
+            ALTER TABLE ioo_nodes ADD COLUMN IF NOT EXISTS difficulty_level INTEGER DEFAULT 5
+        """)
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS ioo_node_proposals (
+                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                title TEXT NOT NULL,
+                description TEXT,
+                goal_category TEXT,
+                step_type TEXT DEFAULT 'hybrid',
+                domain TEXT,
+                tags TEXT[] DEFAULT '{}',
+                source_url TEXT,
+                confidence FLOAT DEFAULT 0.5,
+                status TEXT DEFAULT 'pending',
+                created_at TIMESTAMPTZ DEFAULT NOW()
+            )
+        """)
+        await conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_ioo_node_proposals_status
+            ON ioo_node_proposals(status, created_at DESC)
+        """)
+        try:
+            await conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_ioo_nodes_embedding
+                ON ioo_nodes USING ivfflat (embedding vector_cosine_ops)
+                WITH (lists = 20)
+            """)
+        except Exception:
+            pass  # Needs data first
 
         # Graph edges — weighted paths between nodes
         await conn.execute("""
@@ -1469,8 +1531,16 @@ async def run_migrations():
                 free_time_weekday_hours NUMERIC(4,1),
                 free_time_weekend_hours NUMERIC(4,1),
                 state_json JSONB DEFAULT '{}',
+                embedding vector(1536),
+                embedding_updated_at TIMESTAMPTZ,
                 last_updated TIMESTAMPTZ DEFAULT NOW()
             )
+        """)
+        await conn.execute("""
+            ALTER TABLE ioo_user_state ADD COLUMN IF NOT EXISTS embedding vector(1536)
+        """)
+        await conn.execute("""
+            ALTER TABLE ioo_user_state ADD COLUMN IF NOT EXISTS embedding_updated_at TIMESTAMPTZ
         """)
 
         # Per-user progress tracking through the graph

--- a/core/migrations.sql
+++ b/core/migrations.sql
@@ -562,3 +562,39 @@ CREATE INDEX IF NOT EXISTS idx_contributors_founding_steward
 CREATE INDEX IF NOT EXISTS idx_contributions_ltv_active
     ON contributions(is_ltv_active, ltv_last_evaluated_at)
     WHERE status = 'accepted' AND is_ltv_active = TRUE;
+
+-- ============================================================
+-- IOO Vector Integration (added 2026-04-29)
+-- ============================================================
+
+ALTER TABLE ioo_nodes ADD COLUMN IF NOT EXISTS embedding vector(1536);
+ALTER TABLE ioo_nodes ADD COLUMN IF NOT EXISTS goal_category TEXT;
+ALTER TABLE ioo_user_state ADD COLUMN IF NOT EXISTS embedding vector(1536);
+ALTER TABLE ioo_user_state ADD COLUMN IF NOT EXISTS embedding_updated_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_ioo_nodes_embedding
+    ON ioo_nodes USING ivfflat (embedding vector_cosine_ops)
+    WITH (lists = 20);
+ALTER TABLE ioo_nodes ADD COLUMN IF NOT EXISTS step_type TEXT DEFAULT 'hybrid';
+ALTER TABLE ioo_nodes ADD COLUMN IF NOT EXISTS physical_context TEXT;
+ALTER TABLE ioo_nodes ADD COLUMN IF NOT EXISTS best_time TEXT;
+ALTER TABLE ioo_nodes ADD COLUMN IF NOT EXISTS requirements JSONB DEFAULT '{}';
+ALTER TABLE ioo_nodes ADD COLUMN IF NOT EXISTS estimated_duration_days INTEGER;
+ALTER TABLE ioo_nodes ADD COLUMN IF NOT EXISTS difficulty_level INTEGER DEFAULT 5;
+
+CREATE TABLE IF NOT EXISTS ioo_node_proposals (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    title TEXT NOT NULL,
+    description TEXT,
+    goal_category TEXT,
+    step_type TEXT DEFAULT 'hybrid',
+    domain TEXT,
+    tags TEXT[] DEFAULT '{}',
+    source_url TEXT,
+    confidence FLOAT DEFAULT 0.5,
+    status TEXT DEFAULT 'pending',
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_ioo_node_proposals_status
+    ON ioo_node_proposals(status, created_at DESC);
+ALTER TABLE ioo_nodes ADD COLUMN IF NOT EXISTS prerequisite_nodes UUID[] DEFAULT '{}';

--- a/ora/agents/ioo_enrichment_agent.py
+++ b/ora/agents/ioo_enrichment_agent.py
@@ -1,0 +1,203 @@
+"""
+IOOEnrichmentAgent — daily research loop for growing the IOO graph.
+
+The agent researches evidence-backed pathways across human goal categories,
+turns them into candidate IOO nodes, stores proposals for review, and
+auto-promotes high-confidence, clear/actionable steps into the live graph.
+"""
+
+import hashlib
+import json
+import logging
+import random
+import re
+from datetime import date
+from typing import Any, Dict, List, Optional
+
+from core.config import settings
+from core.database import execute, fetch, fetchrow
+from ora.agents.ioo_graph_agent import get_graph_agent
+
+logger = logging.getLogger(__name__)
+
+
+class IOOEnrichmentAgent:
+    CATEGORIES = [
+        "health/fitness", "mental wellness", "relationships", "career",
+        "finance", "creativity", "spirituality", "learning", "adventure", "community",
+    ]
+
+    QUERY_TEMPLATES = [
+        "complete step-by-step guide to {goal}",
+        "what do you need to achieve {goal}",
+        "science-backed pathway to {goal}",
+        "evidence based steps habits metrics for {goal}",
+    ]
+
+    def __init__(self, openai_client=None):
+        self.openai = openai_client
+
+    def pick_categories(self, count: int = 3) -> List[str]:
+        # Deterministic daily rotation, with slight spread across the list.
+        start = int(hashlib.sha256(str(date.today()).encode()).hexdigest(), 16) % len(self.CATEGORIES)
+        return [self.CATEGORIES[(start + i) % len(self.CATEGORIES)] for i in range(count)]
+
+    async def _search_web(self, query: str) -> List[Dict[str, str]]:
+        """Lightweight web search using DuckDuckGo HTML as a no-key fallback."""
+        try:
+            import html
+            import httpx
+            async with httpx.AsyncClient(timeout=12.0, follow_redirects=True) as client:
+                r = await client.get("https://duckduckgo.com/html/", params={"q": query})
+                r.raise_for_status()
+            results = []
+            blocks = re.findall(r'<div class="result.*?</div>\s*</div>', r.text, flags=re.S)[:5]
+            for block in blocks:
+                link = re.search(r'<a[^>]+class="result__a"[^>]+href="([^"]+)"[^>]*>(.*?)</a>', block, flags=re.S)
+                snippet = re.search(r'<a[^>]+class="result__snippet"[^>]*>(.*?)</a>', block, flags=re.S)
+                if link:
+                    title = re.sub(r"<.*?>", " ", link.group(2))
+                    snip = re.sub(r"<.*?>", " ", snippet.group(1)) if snippet else ""
+                    results.append({
+                        "title": html.unescape(" ".join(title.split())),
+                        "url": html.unescape(link.group(1)),
+                        "snippet": html.unescape(" ".join(snip.split())),
+                    })
+            return results
+        except Exception as e:
+            logger.debug(f"IOO enrichment search failed for {query}: {e}")
+            return []
+
+    def _fallback_steps(self, category: str) -> List[Dict[str, Any]]:
+        templates = {
+            "health/fitness": [
+                ("Schedule 3-4 movement sessions per week", "Create recurring training blocks and start with manageable intensity.", "physical", ["fitness", "habit"]),
+                ("Track daily protein intake for 3 days", "Measure current protein intake before changing the diet.", "hybrid", ["nutrition", "tracking"]),
+                ("Sleep 7-9 hours for recovery", "Protect sleep as the baseline for energy, mood, and adaptation.", "physical", ["sleep", "recovery"]),
+            ],
+            "mental wellness": [
+                ("Complete a 5-minute daily mood check-in", "Track mood and triggers for one week.", "digital", ["mental wellness", "tracking"]),
+                ("Try a guided breathing exercise", "Use a short breath practice to downshift the nervous system.", "digital", ["breathing", "calm"]),
+            ],
+            "finance": [
+                ("List all recurring monthly expenses", "Create visibility before making any financial changes.", "digital", ["finance", "budget"]),
+                ("Set up an automatic savings transfer", "Make saving happen by default each payday.", "digital", ["finance", "automation"]),
+            ],
+        }
+        base = templates.get(category, [
+            (f"Define one measurable {category} outcome", "Turn the broad goal into a concrete target with a date and metric.", "digital", [category, "planning"]),
+            (f"Complete one small real-world {category} action", "Take a small physical or social step that makes the goal real.", "physical", [category, "action"]),
+        ])
+        return [
+            {"title": t, "description": d, "step_type": st, "tags": tags, "confidence": 0.72}
+            for t, d, st, tags in base
+        ]
+
+    async def _extract_steps(self, category: str, results: List[Dict[str, str]]) -> List[Dict[str, Any]]:
+        if not getattr(settings, "OPENAI_API_KEY", ""):
+            return self._fallback_steps(category)
+        try:
+            import httpx
+            source_text = "\n".join(f"- {r['title']}: {r.get('snippet','')} ({r.get('url','')})" for r in results[:8])
+            prompt = f"""
+Extract actionable IOO graph nodes for the goal category: {category}.
+Use the search evidence below. Return JSON only: {{"steps": [{{"title": str, "description": str, "step_type": "digital|physical|hybrid", "tags": [str], "confidence": 0-1, "source_url": str}}]}}
+Prefer clear prerequisites, habits, metrics, physical actions, and digital actions. Avoid vague motivation.
+
+Evidence:
+{source_text}
+"""
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                r = await client.post(
+                    "https://api.openai.com/v1/chat/completions",
+                    headers={"Authorization": f"Bearer {settings.OPENAI_API_KEY}"},
+                    json={
+                        "model": "gpt-4o-mini",
+                        "response_format": {"type": "json_object"},
+                        "messages": [{"role": "user", "content": prompt}],
+                        "temperature": 0.2,
+                    },
+                )
+                r.raise_for_status()
+            data = json.loads(r.json()["choices"][0]["message"]["content"])
+            return data.get("steps") or self._fallback_steps(category)
+        except Exception as e:
+            logger.warning(f"IOO enrichment extraction failed for {category}: {e}")
+            return self._fallback_steps(category)
+
+    async def _similar_exists(self, title: str) -> bool:
+        exact = await fetchrow(
+            "SELECT id FROM ioo_nodes WHERE lower(title) = lower($1) OR title ILIKE $2 LIMIT 1",
+            title, f"%{title[:40]}%",
+        )
+        return bool(exact)
+
+    async def _promote_proposal(self, proposal_id: str) -> Optional[str]:
+        row = await fetchrow("SELECT * FROM ioo_node_proposals WHERE id = $1::uuid", proposal_id)
+        if not row:
+            return None
+        node = await fetchrow(
+            """
+            INSERT INTO ioo_nodes
+                (type, title, description, tags, domain, step_type, goal_category, difficulty_level)
+            VALUES ('activity',$1,$2,$3,$4,$5,$6,5)
+            RETURNING id
+            """,
+            row["title"], row["description"], row["tags"] or [], row["domain"],
+            row["step_type"] or "hybrid", row["goal_category"],
+        )
+        await execute("UPDATE ioo_node_proposals SET status = 'approved' WHERE id = $1::uuid", proposal_id)
+        try:
+            await get_graph_agent().embed_all_nodes()
+        except Exception:
+            pass
+        return str(node["id"]) if node else None
+
+    async def run_daily(self, categories: Optional[List[str]] = None) -> Dict[str, Any]:
+        categories = categories or self.pick_categories(3)
+        proposed = promoted = skipped = 0
+        for category in categories:
+            results: List[Dict[str, str]] = []
+            for tmpl in self.QUERY_TEMPLATES:
+                results.extend(await self._search_web(tmpl.format(goal=category)))
+            steps = await self._extract_steps(category, results)
+            source_url = next((r.get("url") for r in results if r.get("url")), None)
+            for step in steps[:8]:
+                title = (step.get("title") or "").strip()
+                if len(title) < 8 or await self._similar_exists(title):
+                    skipped += 1
+                    continue
+                confidence = float(step.get("confidence") or 0.5)
+                status = "approved" if confidence >= 0.82 else "pending"
+                row = await fetchrow(
+                    """
+                    INSERT INTO ioo_node_proposals
+                        (title, description, goal_category, step_type, domain, tags, source_url, confidence, status)
+                    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+                    RETURNING id
+                    """,
+                    title,
+                    step.get("description"),
+                    category,
+                    step.get("step_type") if step.get("step_type") in ("digital", "physical", "hybrid") else "hybrid",
+                    step.get("domain") or "iVive",
+                    step.get("tags") or [category],
+                    step.get("source_url") or source_url,
+                    confidence,
+                    status,
+                )
+                proposed += 1
+                if status == "approved":
+                    if await self._promote_proposal(str(row["id"])):
+                        promoted += 1
+        return {"ok": True, "categories": categories, "proposed": proposed, "promoted": promoted, "skipped": skipped}
+
+
+_enrichment_agent: Optional[IOOEnrichmentAgent] = None
+
+
+def get_ioo_enrichment_agent(openai_client=None) -> IOOEnrichmentAgent:
+    global _enrichment_agent
+    if _enrichment_agent is None:
+        _enrichment_agent = IOOEnrichmentAgent(openai_client)
+    return _enrichment_agent

--- a/ora/agents/ioo_graph_agent.py
+++ b/ora/agents/ioo_graph_agent.py
@@ -11,13 +11,71 @@ rise to the top over time.
 
 import logging
 import json
-from typing import Optional
+import math
+import re
+from datetime import datetime, timezone
+from typing import Optional, List
 from uuid import UUID
 
+from core.config import settings
 from core.database import fetch, fetchrow, fetchval, execute
+from ora.agents.recommendation_engine import (
+    _embedding_to_pgvector,
+    _hash_text_to_embedding,
+)
 
 logger = logging.getLogger(__name__)
 
+
+def _parse_pgvector(raw) -> List[float]:
+    """Convert asyncpg/pgvector/string values into a Python vector."""
+    if raw is None:
+        return []
+    if isinstance(raw, list):
+        return [float(v) for v in raw]
+    if isinstance(raw, tuple):
+        return [float(v) for v in raw]
+    text = str(raw).strip()
+    if not text:
+        return []
+    try:
+        return [float(v) for v in text.strip("[]").split(",") if v.strip()]
+    except Exception:
+        try:
+            return [float(v) for v in json.loads(text)]
+        except Exception:
+            return []
+
+
+def _normalize_vector(values: List[float]) -> List[float]:
+    norm = math.sqrt(sum(v * v for v in values))
+    if norm <= 0:
+        return values
+    return [v / norm for v in values]
+
+
+def _node_embedding_text(node: dict) -> str:
+    tags = node.get("tags") or []
+    if isinstance(tags, str):
+        try:
+            tags = json.loads(tags)
+        except Exception:
+            tags = [tags]
+    return " | ".join(
+        str(part)
+        for part in [
+            f"title: {node.get('title') or ''}",
+            f"description: {node.get('description') or ''}",
+            f"domain: {node.get('domain') or ''}",
+            f"tags: {', '.join(tags)}",
+            f"node_type: {node.get('type') or node.get('node_type') or ''}",
+            f"step_type: {node.get('step_type') or ''}",
+            f"physical_context: {node.get('physical_context') or ''}",
+            f"best_time: {node.get('best_time') or ''}",
+            f"goal_category: {node.get('goal_category') or ''}",
+        ]
+        if part
+    )
 
 class IOOGraphAgent:
     """Traverses and learns the IOO achievement graph."""
@@ -194,6 +252,679 @@ class IOOGraphAgent:
 
         rows = await fetch(simple_query, *final_params)
         return [dict(r) for r in rows]
+
+
+    # ------------------------------------------------------------------
+    # Vector embeddings / recommendations
+    # ------------------------------------------------------------------
+
+    async def _ensure_vector_schema(self) -> None:
+        """Idempotently add IOO vector columns/indexes."""
+        await execute("ALTER TABLE ioo_nodes ADD COLUMN IF NOT EXISTS embedding vector(1536)")
+        await execute("ALTER TABLE ioo_nodes ADD COLUMN IF NOT EXISTS goal_category TEXT")
+        await execute("ALTER TABLE ioo_nodes ADD COLUMN IF NOT EXISTS step_type TEXT DEFAULT 'hybrid'")
+        await execute("ALTER TABLE ioo_nodes ADD COLUMN IF NOT EXISTS physical_context TEXT")
+        await execute("ALTER TABLE ioo_nodes ADD COLUMN IF NOT EXISTS best_time TEXT")
+        await execute("ALTER TABLE ioo_nodes ADD COLUMN IF NOT EXISTS requirements JSONB DEFAULT '{}'")
+        await execute("ALTER TABLE ioo_nodes ADD COLUMN IF NOT EXISTS prerequisite_nodes UUID[] DEFAULT '{}'")
+        await execute("ALTER TABLE ioo_nodes ADD COLUMN IF NOT EXISTS estimated_duration_days INTEGER")
+        await execute("ALTER TABLE ioo_nodes ADD COLUMN IF NOT EXISTS difficulty_level INTEGER DEFAULT 5")
+        await execute(
+            """
+            CREATE TABLE IF NOT EXISTS ioo_node_proposals (
+                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                title TEXT NOT NULL,
+                description TEXT,
+                goal_category TEXT,
+                step_type TEXT DEFAULT 'hybrid',
+                domain TEXT,
+                tags TEXT[] DEFAULT '{}',
+                source_url TEXT,
+                confidence FLOAT DEFAULT 0.5,
+                status TEXT DEFAULT 'pending',
+                created_at TIMESTAMPTZ DEFAULT NOW()
+            )
+            """
+        )
+        await execute("ALTER TABLE ioo_user_state ADD COLUMN IF NOT EXISTS embedding vector(1536)")
+        await execute("ALTER TABLE ioo_user_state ADD COLUMN IF NOT EXISTS embedding_updated_at TIMESTAMPTZ")
+        try:
+            await execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_ioo_nodes_embedding
+                ON ioo_nodes USING ivfflat (embedding vector_cosine_ops)
+                WITH (lists = 20)
+                """
+            )
+        except Exception as e:
+            logger.debug(f"IOO vector index creation skipped: {e}")
+
+    async def _embed_text(self, text: str) -> List[float]:
+        """Embed text with OpenAI when configured; otherwise deterministic hash fallback."""
+        api_key = getattr(settings, "OPENAI_API_KEY", "")
+        if api_key:
+            try:
+                import httpx
+                async with httpx.AsyncClient(timeout=15.0) as client:
+                    r = await client.post(
+                        "https://api.openai.com/v1/embeddings",
+                        headers={"Authorization": f"Bearer {api_key}"},
+                        json={"model": "text-embedding-3-small", "input": text[:8000]},
+                    )
+                    r.raise_for_status()
+                    return r.json()["data"][0]["embedding"]
+            except Exception as e:
+                logger.warning(f"IOO OpenAI embedding failed: {e} — using hash fallback")
+        return _hash_text_to_embedding(text)
+
+    async def embed_all_nodes(self) -> int:
+        """Generate and store embeddings for all IOO nodes that don't have one yet.
+        Uses OpenAI text-embedding-3-small (1536 dims) when key is available.
+        Returns number of nodes embedded."""
+        await self._ensure_vector_schema()
+        rows = await fetch(
+            """
+            SELECT id, type, title, description, tags, domain, goal_category, step_type, physical_context, best_time
+            FROM ioo_nodes
+            WHERE is_active = TRUE AND embedding IS NULL
+            ORDER BY created_at ASC
+            """
+        )
+        embedded = 0
+        for row in rows:
+            node = dict(row)
+            emb = await self._embed_text(_node_embedding_text(node))
+            if not emb:
+                continue
+            await execute(
+                "UPDATE ioo_nodes SET embedding = $2::vector, updated_at = NOW() WHERE id = $1",
+                str(node["id"]),
+                _embedding_to_pgvector(emb),
+            )
+            embedded += 1
+        return embedded
+
+    async def _capability_filter_sql(self, user_id: str, start_idx: int = 3) -> tuple[str, list]:
+        user_state = await fetchrow("SELECT * FROM ioo_user_state WHERE user_id = $1", str(user_id))
+        clauses: list[str] = []
+        params: list = []
+        idx = start_idx
+        if user_state:
+            budget = user_state["finances_monthly_budget_usd"]
+            if budget is not None:
+                clauses.append(f"AND (n.requires_finances IS NULL OR n.requires_finances <= ${idx})")
+                params.append(float(budget)); idx += 1
+            fitness = user_state["fitness_level"]
+            if fitness is not None:
+                clauses.append(f"AND (n.requires_fitness_level IS NULL OR n.requires_fitness_level <= ${idx})")
+                params.append(int(fitness)); idx += 1
+            city = user_state["location_city"]
+            country = user_state["location_country"]
+            if city or country:
+                clauses.append(f"AND (n.requires_location IS NULL OR n.requires_location ILIKE ${idx} OR n.requires_location ILIKE ${idx+1})")
+                params.extend([f"%{city}%" if city else "%", f"%{country}%" if country else "%"])
+                idx += 2
+
+            # Physical feasibility: only suggest physical/hybrid steps that fit
+            # known available time and basic transport constraints.
+            weekday = user_state["free_time_weekday_hours"]
+            weekend = user_state["free_time_weekend_hours"]
+            available_time = max(
+                float(weekday or 0),
+                float(weekend or 0),
+            )
+            if available_time > 0:
+                clauses.append(
+                    f"AND (n.step_type = 'digital' OR n.requires_time_hours IS NULL OR n.requires_time_hours <= ${idx})"
+                )
+                params.append(available_time)
+                idx += 1
+
+            has_car = user_state["has_car"]
+            if has_car is False:
+                clauses.append(
+                    "AND (n.physical_context IS NULL OR n.physical_context NOT ILIKE '%car%')"
+                )
+        return "\n".join(clauses), params
+
+    async def vector_recommend(
+        self,
+        user_id: str,
+        goal_context: str,
+        limit: int = 10,
+        preference: str = "mixed",
+    ) -> list:
+        """
+        Vector similarity recommendation using the user's goal context.
+        1. Embed the user's current goal/context string
+        2. Find IOO nodes with cosine similarity (pgvector <=> operator)
+        3. Blend with capability filters and edge weight scoring
+        4. Return ranked list of recommended nodes
+        """
+        await self._ensure_vector_schema()
+        if await fetchval("SELECT COUNT(*) FROM ioo_nodes WHERE is_active = TRUE AND embedding IS NULL"):
+            await self.embed_all_nodes()
+
+        goal_emb = await self._embed_text(goal_context or "personal growth real-world experience")
+        query_vec = _embedding_to_pgvector(goal_emb)
+
+        completed_rows = await fetch(
+            "SELECT node_id FROM ioo_user_progress WHERE user_id = $1 AND status = 'completed'",
+            str(user_id),
+        )
+        completed_ids = [str(r["node_id"]) for r in completed_rows]
+        capability_sql, capability_params = await self._capability_filter_sql(str(user_id), start_idx=4)
+        preference = preference if preference in ("prefer_digital", "prefer_physical", "mixed") else "mixed"
+        preference_score_sql = ""
+        if preference == "prefer_digital":
+            preference_score_sql = " + CASE WHEN n.step_type = 'digital' THEN 0.10 WHEN n.step_type = 'hybrid' THEN 0.05 ELSE 0 END"
+        elif preference == "prefer_physical":
+            preference_score_sql = " + CASE WHEN n.step_type = 'physical' THEN 0.10 WHEN n.step_type = 'hybrid' THEN 0.05 ELSE 0 END"
+
+        rows = await fetch(
+            f"""
+            SELECT
+                n.id, n.type, n.title, n.description, n.tags, n.domain, n.goal_category,
+                n.step_type, n.physical_context, n.best_time,
+                n.requires_finances, n.requires_fitness_level, n.requires_skills,
+                n.requires_location, n.requires_time_hours,
+                n.attempt_count, n.success_count, n.avg_completion_hours,
+                1 - (n.embedding <=> $2::vector) AS vector_similarity,
+                COALESCE((
+                    SELECT MAX(e.weight) FROM ioo_edges e
+                    WHERE e.to_node_id = n.id
+                      AND e.from_node_id::text = ANY($3::text[])
+                ), 0.5) AS edge_weight,
+                CASE WHEN n.attempt_count > 0
+                     THEN n.success_count::float / n.attempt_count
+                     ELSE 0.5
+                END AS success_rate
+            FROM ioo_nodes n
+            WHERE n.is_active = TRUE
+              AND n.embedding IS NOT NULL
+              AND n.id NOT IN (
+                  SELECT node_id FROM ioo_user_progress
+                  WHERE user_id = $1 AND status IN ('completed', 'abandoned')
+              )
+              {capability_sql}
+            ORDER BY (
+                (1 - (n.embedding <=> $2::vector)) * 0.60 +
+                COALESCE((
+                    SELECT MAX(e.weight) FROM ioo_edges e
+                    WHERE e.to_node_id = n.id
+                      AND e.from_node_id::text = ANY($3::text[])
+                ), 0.5) * 0.25 +
+                (CASE WHEN n.attempt_count > 0 THEN n.success_count::float / n.attempt_count ELSE 0.5 END) * 0.15
+                {preference_score_sql}
+            ) DESC
+            LIMIT ${4 + len(capability_params)}
+            """,
+            str(user_id),
+            query_vec,
+            completed_ids,
+            *capability_params,
+            limit,
+        )
+        return [dict(r) for r in rows]
+
+
+    async def find_path(
+        self,
+        user_id: str,
+        goal_node_id: str,
+        max_steps: int = 10,
+        preference: str = "mixed",
+    ) -> list[dict]:
+        """
+        Compute the optimal step-by-step path from user's current position to a goal node.
+        Like Google Maps turn-by-turn directions.
+
+        Returns ordered list of nodes: [step1, step2, step3, ... goal]
+        Each step has: node_id, title, description, estimated_time, why_this_step
+        """
+        await self._ensure_vector_schema()
+
+        goal = await fetchrow(
+            """
+            SELECT id, type, title, description, tags, domain, requires_time_hours, embedding,
+                   step_type, physical_context, best_time, goal_category
+            FROM ioo_nodes
+            WHERE id = $1::uuid AND is_active = TRUE
+            """,
+            str(goal_node_id),
+        )
+        if not goal:
+            return []
+
+        completed_rows = await fetch(
+            """
+            SELECT node_id FROM ioo_user_progress
+            WHERE user_id = $1 AND status = 'completed'
+            """,
+            str(user_id),
+        )
+        completed_ids = {str(r["node_id"]) for r in completed_rows}
+        if str(goal["id"]) in completed_ids:
+            return []
+
+        capability_sql, capability_params = await self._capability_filter_sql(str(user_id), start_idx=3)
+        cap_param_count = len(capability_params)
+        shifted_capability_sql = re.sub(
+            r"\$(\d+)",
+            lambda m: f"${int(m.group(1)) + cap_param_count}",
+            capability_sql,
+        )
+        goal_param_idx = 3 + cap_param_count * 2
+        preference = preference if preference in ("prefer_digital", "prefer_physical", "mixed") else "mixed"
+        path_preference_sql = ""
+        if preference == "prefer_digital":
+            path_preference_sql = "CASE WHEN n.step_type = 'digital' THEN 1.10 WHEN n.step_type = 'hybrid' THEN 1.05 ELSE 0.95 END"
+        elif preference == "prefer_physical":
+            path_preference_sql = "CASE WHEN n.step_type = 'physical' THEN 1.10 WHEN n.step_type = 'hybrid' THEN 1.05 ELSE 0.95 END"
+        else:
+            path_preference_sql = "1.0"
+
+        # First try real graph pathfinding: reverse BFS/DFS from current completed
+        # nodes (or root activities when user has no completed nodes) toward the goal.
+        rows = await fetch(
+            f"""
+            WITH RECURSIVE paths AS (
+                -- Starting point: completed nodes if present, otherwise low-friction roots.
+                SELECT
+                    n.id AS node_id,
+                    ARRAY[n.id] AS path_ids,
+                    0 AS depth,
+                    1.0::float AS path_quality,
+                    COALESCE(n.requires_time_hours, 1)::float AS total_time
+                FROM ioo_nodes n
+                WHERE n.is_active = TRUE
+                  AND (
+                    (cardinality($1::uuid[]) > 0 AND n.id = ANY($1::uuid[]))
+                    OR
+                    (cardinality($1::uuid[]) = 0 AND n.id NOT IN (SELECT to_node_id FROM ioo_edges))
+                  )
+                  {capability_sql}
+
+                UNION ALL
+
+                SELECT
+                    e.to_node_id AS node_id,
+                    p.path_ids || e.to_node_id,
+                    p.depth + 1,
+                    p.path_quality * COALESCE(e.weight, 0.5)::float *
+                        (CASE WHEN n.attempt_count > 0 THEN n.success_count::float / n.attempt_count ELSE 0.5 END) *
+                        ({path_preference_sql}),
+                    p.total_time + COALESCE(n.requires_time_hours, 1)::float
+                FROM paths p
+                JOIN ioo_edges e ON e.from_node_id = p.node_id
+                JOIN ioo_nodes n ON n.id = e.to_node_id
+                WHERE p.depth < $2
+                  AND n.is_active = TRUE
+                  AND NOT e.to_node_id = ANY(p.path_ids)
+                  AND NOT e.to_node_id = ANY($1::uuid[])
+                  {shifted_capability_sql}
+            )
+            SELECT path_ids, depth, path_quality, total_time
+            FROM paths
+            WHERE node_id = ${goal_param_idx}::uuid
+            ORDER BY
+                depth ASC,
+                path_quality DESC,
+                total_time ASC
+            LIMIT 1
+            """,
+            list(completed_ids),
+            max_steps,
+            *capability_params,
+            *capability_params,
+            str(goal_node_id),
+        )
+
+        path_ids: list[str] = []
+        if rows:
+            raw_ids = rows[0]["path_ids"]
+            path_ids = [str(pid) for pid in raw_ids if str(pid) not in completed_ids]
+
+        # Fallback: if graph edges are sparse, use vector recommendations as
+        # semantic stepping stones and end at the goal. This keeps the UX useful
+        # while the IOO graph is still learning edges.
+        if not path_ids:
+            goal_context = _node_embedding_text(dict(goal))
+            semantic_steps = await self.vector_recommend(
+                user_id=str(user_id),
+                goal_context=goal_context,
+                limit=max(1, max_steps - 1),
+                preference=preference,
+            )
+            seen = set(completed_ids)
+            for step in semantic_steps:
+                sid = str(step["id"])
+                if sid == str(goal_node_id) or sid in seen:
+                    continue
+                path_ids.append(sid)
+                seen.add(sid)
+            path_ids.append(str(goal_node_id))
+
+        if str(goal_node_id) not in path_ids:
+            path_ids.append(str(goal_node_id))
+        path_ids = path_ids[:max_steps]
+
+        node_rows = await fetch(
+            """
+            SELECT id, type, title, description, tags, domain, requires_time_hours,
+                   step_type, physical_context, best_time,
+                   requires_finances, requires_fitness_level, attempt_count, success_count
+            FROM ioo_nodes
+            WHERE id::text = ANY($1::text[])
+            """,
+            path_ids,
+        )
+        by_id = {str(r["id"]): dict(r) for r in node_rows}
+        ordered: list[dict] = []
+        total = len(path_ids)
+        for index, node_id in enumerate(path_ids, start=1):
+            node = by_id.get(str(node_id))
+            if not node:
+                continue
+            is_goal = str(node_id) == str(goal_node_id)
+            if is_goal:
+                why = "This is your destination — the outcome Ora is mapping you toward."
+            elif index == 1:
+                why = "This is the next reachable step from where you are now."
+            else:
+                why = "This builds on the previous step and moves you closer to the destination."
+            if node.get("attempt_count"):
+                success_rate = (node.get("success_count") or 0) / max(float(node.get("attempt_count") or 1), 1.0)
+                why += f" Similar users complete it about {round(success_rate * 100)}% of the time."
+            ordered.append({
+                "step": index,
+                "node_id": str(node["id"]),
+                "title": node.get("title"),
+                "description": node.get("description"),
+                "type": node.get("type"),
+                "domain": node.get("domain"),
+                "estimated_time": float(node["requires_time_hours"]) if node.get("requires_time_hours") is not None else None,
+                "step_type": node.get("step_type") or "hybrid",
+                "physical_context": node.get("physical_context"),
+                "best_time": node.get("best_time"),
+                "why_this_step": why,
+                "is_goal": is_goal,
+                "remaining_steps": max(total - index, 0),
+            })
+        return ordered
+
+
+    async def check_node_eligibility(self, user_id: str, node_id: str) -> dict:
+        """Check if a user is eligible to attempt a node and identify gaps."""
+        await self._ensure_vector_schema()
+        node = await fetchrow(
+            """
+            SELECT id, title, requirements, prerequisite_nodes, requires_finances, requires_fitness_level,
+                   requires_skills, requires_location, requires_time_hours, step_type,
+                   physical_context
+            FROM ioo_nodes WHERE id = $1::uuid AND is_active = TRUE
+            """,
+            str(node_id),
+        )
+        if not node:
+            return {"eligible": False, "gaps": [{"type": "missing_node", "message": "Node not found"}], "bridge_nodes": []}
+
+        state = await fetchrow("SELECT * FROM ioo_user_state WHERE user_id = $1", str(user_id))
+        completed = await fetch(
+            "SELECT node_id::text FROM ioo_user_progress WHERE user_id = $1 AND status = 'completed'",
+            str(user_id),
+        )
+        completed_ids = {r["node_id"] for r in completed}
+        req = node["requirements"] or {}
+        if isinstance(req, str):
+            try:
+                req = json.loads(req)
+            except Exception:
+                req = {}
+
+        gaps: list[dict] = []
+        def gap(kind: str, message: str, **extra):
+            gaps.append({"type": kind, "message": message, **extra})
+
+        budget_req = req.get("min_budget_usd") or node["requires_finances"]
+        if budget_req is not None and state and state["finances_monthly_budget_usd"] is not None:
+            if float(state["finances_monthly_budget_usd"]) < float(budget_req):
+                gap("budget", f"Needs about ${float(budget_req):.0f} available budget", required=float(budget_req), current=float(state["finances_monthly_budget_usd"]))
+
+        fitness_req = req.get("min_fitness_level") or node["requires_fitness_level"]
+        current_fitness = state["fitness_level"] if state else None
+        if fitness_req is not None and current_fitness is not None and int(current_fitness) < int(fitness_req):
+            gap("fitness", f"Needs fitness level {fitness_req}; current estimate is {current_fitness}", required=int(fitness_req), current=int(current_fitness))
+
+        needed_skills = set(req.get("required_skills") or node["requires_skills"] or [])
+        known_skills = set(state["known_skills"] or []) if state else set()
+        missing_skills = sorted(needed_skills - known_skills)
+        if missing_skills:
+            gap("skills", "Missing prerequisite skills", missing=missing_skills)
+
+        prereqs = [str(x) for x in (req.get("prerequisite_node_ids") or node["prerequisite_nodes"] or [])]
+        missing_prereqs = [pid for pid in prereqs if pid not in completed_ids]
+        if missing_prereqs:
+            gap("prior_nodes", "Needs prerequisite nodes completed first", missing=missing_prereqs)
+
+        if node["step_type"] in ("physical", "hybrid") and state:
+            available_time = max(float(state["free_time_weekday_hours"] or 0), float(state["free_time_weekend_hours"] or 0))
+            required_time = req.get("time_per_week_hours") or node["requires_time_hours"]
+            if required_time and available_time and available_time < float(required_time):
+                gap("time", f"Needs {float(required_time):.1f}h available; current estimate is {available_time:.1f}h", required=float(required_time), current=available_time)
+            if (req.get("requires_location") or node["requires_location"]) and not (state["location_city"] or state["location_country"]):
+                gap("location", "Needs a location context to find a feasible physical option")
+            equipment = req.get("required_equipment") or []
+            if any(str(e).lower() in ("gym_membership", "car", "transport") for e in equipment):
+                if "car" in [str(e).lower() for e in equipment] and state["has_car"] is False:
+                    gap("transport", "Needs transport access or a closer alternative")
+
+        bridge_nodes = []
+        if gaps:
+            ids = await self.spawn_prerequisite_nodes(user_id, node_id, gaps)
+            if ids:
+                rows = await fetch("SELECT id, title, description, step_type FROM ioo_nodes WHERE id::text = ANY($1::text[])", ids)
+                bridge_nodes = [dict(r) for r in rows]
+        return {"eligible": not gaps, "gaps": gaps, "bridge_nodes": bridge_nodes}
+
+    async def spawn_prerequisite_nodes(self, user_id: str, node_id: str, gaps: list) -> list[str]:
+        """Find/create bridge nodes for unmet requirements."""
+        await self._ensure_vector_schema()
+        created_or_found: list[str] = []
+        target = await fetchrow("SELECT title, goal_category, domain FROM ioo_nodes WHERE id = $1::uuid", str(node_id))
+        target_title = target["title"] if target else "this goal"
+        category = target["goal_category"] if target else None
+        domain = target["domain"] if target else "iVive"
+
+        templates = {
+            "budget": ("Create a simple budget for {target}", "Work out the minimum cost and choose the lowest-friction way to fund this step.", "digital", ["finance", "planning"]),
+            "fitness": ("Complete a 2-week foundation program for {target}", "Build baseline strength/endurance before attempting the next physical step.", "physical", ["fitness", "foundation"]),
+            "skills": ("Learn the basic skills needed for {target}", "Complete a short primer/practice block for the missing prerequisite skills.", "digital", ["learning", "skills"]),
+            "prior_nodes": ("Complete prerequisite step for {target}", "Finish the required prior node before moving forward.", "hybrid", ["prerequisite"]),
+            "time": ("Schedule time blocks for {target}", "Create protected calendar time so this goal has room in the week.", "digital", ["planning", "time"]),
+            "location": ("Find a nearby place for {target}", "Locate a feasible nearby option based on your city and transport constraints.", "digital", ["local", "planning"]),
+            "transport": ("Find a walkable or transit-accessible option for {target}", "Avoid car-dependency by finding a closer route or transit option.", "digital", ["transport", "local"]),
+        }
+
+        for gap in gaps:
+            tpl = templates.get(gap.get("type"), ("Prepare for {target}", "Close the prerequisite gap before attempting this step.", "hybrid", ["preparation"]))
+            title = tpl[0].format(target=target_title)
+            existing = await fetchrow(
+                """
+                SELECT id FROM ioo_nodes
+                WHERE lower(title) = lower($1) OR title ILIKE $2
+                LIMIT 1
+                """,
+                title,
+                f"%{title[:40]}%",
+            )
+            if existing:
+                created_or_found.append(str(existing["id"]))
+                continue
+            proposal = await fetchrow(
+                """
+                INSERT INTO ioo_node_proposals
+                    (title, description, goal_category, step_type, domain, tags, confidence, status)
+                VALUES ($1,$2,$3,$4,$5,$6,0.86,'approved')
+                RETURNING id
+                """,
+                title, tpl[1], category, tpl[2], domain, tpl[3],
+            )
+            row = await fetchrow(
+                """
+                INSERT INTO ioo_nodes
+                    (type, title, description, tags, domain, step_type, goal_category,
+                     requirements, difficulty_level)
+                VALUES ('activity',$1,$2,$3,$4,$5,$6,$7::jsonb,3)
+                RETURNING id
+                """,
+                title, tpl[1], tpl[3], domain, tpl[2], category,
+                json.dumps({"bridge_for_node_id": str(node_id), "gap_type": gap.get("type")}),
+            )
+            if row:
+                created_or_found.append(str(row["id"]))
+                await execute(
+                    "INSERT INTO ioo_edges (from_node_id, to_node_id) VALUES ($1::uuid,$2::uuid) ON CONFLICT DO NOTHING",
+                    str(row["id"]), str(node_id),
+                )
+        return created_or_found
+
+    async def build_personalised_path(
+        self,
+        user_id: str,
+        goal_node_id: str,
+        max_steps: int = 10,
+        preference: str = "mixed",
+    ) -> list[dict]:
+        """Full GPS-style route with dynamically spawned prerequisite bridge nodes."""
+        base_path = await self.find_path(user_id, goal_node_id, max_steps=max_steps, preference=preference)
+        personalised: list[dict] = []
+        seen: set[str] = set()
+        for step in base_path:
+            node_id = str(step["node_id"])
+            eligibility = await self.check_node_eligibility(user_id, node_id)
+            if not eligibility.get("eligible"):
+                for bridge in eligibility.get("bridge_nodes", []):
+                    bid = str(bridge["id"])
+                    if bid in seen:
+                        continue
+                    personalised.append({
+                        "step": len(personalised) + 1,
+                        "node_id": bid,
+                        "title": bridge.get("title"),
+                        "description": bridge.get("description"),
+                        "step_type": bridge.get("step_type") or "hybrid",
+                        "is_prerequisite": True,
+                        "unblocks_node_id": node_id,
+                        "why_this_step": "Ora spawned this bridge step because a requirement gap blocks the next node.",
+                    })
+                    seen.add(bid)
+            if node_id not in seen:
+                step["step"] = len(personalised) + 1
+                step["is_prerequisite"] = False
+                step["eligibility"] = {"eligible": eligibility.get("eligible"), "gaps": eligibility.get("gaps", [])}
+                personalised.append(step)
+                seen.add(node_id)
+        return personalised
+
+    async def build_user_ioo_vector(self, user_id: str) -> List[float]:
+        """Build and store the user's IOO fingerprint from completed/in-progress nodes."""
+        await self._ensure_vector_schema()
+        rows = await fetch(
+            """
+            SELECT p.status, p.started_at, p.completed_at, p.created_at,
+                   n.id, n.embedding, n.title, n.description, n.tags, n.domain, n.type, n.goal_category
+            FROM ioo_user_progress p
+            JOIN ioo_nodes n ON n.id = p.node_id
+            WHERE p.user_id = $1
+              AND p.status IN ('completed', 'started', 'viewed')
+            ORDER BY COALESCE(p.completed_at, p.started_at, p.created_at) DESC
+            LIMIT 50
+            """,
+            str(user_id),
+        )
+        if not rows:
+            return []
+
+        vectors: list[tuple[List[float], float]] = []
+        now = datetime.now(timezone.utc)
+        for row in rows:
+            raw = row["embedding"]
+            if not raw:
+                node = dict(row)
+                emb = await self._embed_text(_node_embedding_text(node))
+                await execute(
+                    "UPDATE ioo_nodes SET embedding = $2::vector, updated_at = NOW() WHERE id = $1",
+                    str(row["id"]),
+                    _embedding_to_pgvector(emb),
+                )
+            else:
+                emb = _parse_pgvector(raw)
+            if not emb:
+                continue
+            event_at = row["completed_at"] or row["started_at"] or row["created_at"] or now
+            if event_at.tzinfo is None:
+                event_at = event_at.replace(tzinfo=timezone.utc)
+            age_days = max(0.0, (now - event_at).total_seconds() / 86400.0)
+            recency_weight = 1.0 / (1.0 + age_days / 30.0)
+            status_weight = {"completed": 1.0, "started": 0.65, "viewed": 0.35}.get(row["status"], 0.5)
+            vectors.append((emb, recency_weight * status_weight))
+
+        if not vectors:
+            return []
+        total_weight = sum(w for _, w in vectors) or 1.0
+        dim = len(vectors[0][0])
+        avg = [0.0] * dim
+        for emb, weight in vectors:
+            for i, val in enumerate(emb[:dim]):
+                avg[i] += val * weight
+        avg = _normalize_vector([v / total_weight for v in avg])
+        await execute(
+            """
+            INSERT INTO ioo_user_state (user_id, embedding, embedding_updated_at)
+            VALUES ($1::uuid, $2::vector, NOW())
+            ON CONFLICT (user_id) DO UPDATE
+            SET embedding = $2::vector, embedding_updated_at = NOW(), last_updated = NOW()
+            """,
+            str(user_id),
+            _embedding_to_pgvector(avg),
+        )
+        return avg
+
+    async def get_user_vector_summary(self, user_id: str) -> dict:
+        """Return a safe summary of the user's IOO fingerprint, not the raw vector."""
+        vector = await self.build_user_ioo_vector(user_id)
+        progress_counts = await fetch(
+            """
+            SELECT status, COUNT(*) AS count
+            FROM ioo_user_progress
+            WHERE user_id = $1
+            GROUP BY status
+            """,
+            str(user_id),
+        )
+        top_nodes = []
+        if vector:
+            try:
+                rows = await fetch(
+                    """
+                    SELECT title, type, domain, 1 - (embedding <=> $1::vector) AS similarity
+                    FROM ioo_nodes
+                    WHERE embedding IS NOT NULL AND is_active = TRUE
+                    ORDER BY embedding <=> $1::vector
+                    LIMIT 5
+                    """,
+                    _embedding_to_pgvector(vector),
+                )
+                top_nodes = [dict(r) for r in rows]
+            except Exception as e:
+                logger.debug(f"IOO vector summary nearest nodes failed: {e}")
+        return {
+            "has_vector": bool(vector),
+            "dimensions": len(vector) if vector else 0,
+            "progress_counts": {r["status"]: r["count"] for r in progress_counts},
+            "nearest_nodes": top_nodes,
+        }
 
     # ------------------------------------------------------------------
     # Traversal recording
@@ -470,6 +1201,18 @@ class IOOGraphAgent:
         node_ids: dict = {}
 
         for node in nodes:
+            tags_l = set(node.get("tags", []))
+            if "step_type" not in node:
+                if tags_l & {"fitness", "running", "travel", "community", "social", "music"}:
+                    node["step_type"] = "physical"
+                elif tags_l & {"tech", "product", "research", "writing", "planning"}:
+                    node["step_type"] = "digital"
+                else:
+                    node["step_type"] = "hybrid"
+            if node.get("step_type") == "physical":
+                node.setdefault("physical_context", "Requires real-world availability; may depend on local access.")
+                node.setdefault("best_time", "flexible")
+
             existing_id = await fetchval(
                 "SELECT id FROM ioo_nodes WHERE title = $1",
                 node["title"],
@@ -485,8 +1228,9 @@ class IOOGraphAgent:
                 INSERT INTO ioo_nodes
                     (type, title, description, tags, domain,
                      requires_finances, requires_fitness_level, requires_skills,
-                     requires_location, requires_time_hours)
-                VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+                     requires_location, requires_time_hours,
+                     step_type, physical_context, best_time)
+                VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
                 RETURNING id
                 """,
                 node["type"],
@@ -499,6 +1243,9 @@ class IOOGraphAgent:
                 skills,
                 node.get("requires_location"),
                 node.get("requires_time_hours"),
+                node.get("step_type", "hybrid"),
+                node.get("physical_context"),
+                node.get("best_time"),
             )
             if row:
                 node_ids[node["title"]] = str(row["id"])

--- a/ora/agents/recommendation_engine.py
+++ b/ora/agents/recommendation_engine.py
@@ -54,6 +54,7 @@ EXPLOIT_RATIO = 0.80    # 80% from exploit pool
 # EMA alpha for user embedding updates
 EMA_ALPHA = 0.10        # new = alpha * card_emb + (1-alpha) * old_emb
 GOAL_BLEND_RATIO = 0.30  # 30% goal embedding, 70% behavioral
+IOO_BLEND_RATIO = 0.25   # 25% IOO graph fingerprint, 75% behavioral/goal blend
 
 
 def _hash_text_to_embedding(text: str, dim: int = EMBEDDING_DIM) -> List[float]:
@@ -468,10 +469,11 @@ class RecommendationEngine:
 
         Algorithm:
         1. Fetch user's combined_embedding
-        2. Vector similarity search against card_popularity
-        3. Re-rank by: similarity*0.6 + avg_rating/5*0.3 + recency_bonus*0.1
-        4. Insert explore cards (20%)
-        5. Return final ranked list
+        2. Pull the user's IOO vector profile and blend it in
+        3. Vector similarity search against card_popularity
+        4. Re-rank by similarity, quality, recency, and IOO alignment
+        5. Insert explore cards (20%)
+        6. Return final ranked list
         """
         try:
             # Fetch user embedding
@@ -479,6 +481,13 @@ class RecommendationEngine:
                 "SELECT combined_embedding, total_cards_rated FROM user_interest_vectors WHERE user_id = $1::uuid",
                 user_id,
             )
+
+            ioo_vector: List[float] = []
+            try:
+                from ora.agents.ioo_graph_agent import get_graph_agent
+                ioo_vector = await get_graph_agent().build_user_ioo_vector(user_id)
+            except Exception as ioe:
+                logger.debug(f"RecommendationEngine: IOO profile unavailable: {ioe}")
 
             # Get recently seen cards (last 7 days)
             recent_seen = await fetch(
@@ -500,9 +509,20 @@ class RecommendationEngine:
             explore_cards = []
 
             if uiv_row and uiv_row["combined_embedding"] and uiv_row["total_cards_rated"] > 5:
-                # Vector similarity search for exploit pool
+                # Vector similarity search for exploit pool. Blend Ora's
+                # behavioral/goal vector with the IOO graph fingerprint so feed
+                # cards preferentially align with where the user is in their
+                # achievement graph.
                 raw_emb = uiv_row["combined_embedding"]
-                emb_str = raw_emb if isinstance(raw_emb, str) else _embedding_to_pgvector(list(raw_emb))
+                behavior_emb = json.loads(raw_emb) if isinstance(raw_emb, str) else list(raw_emb)
+                if ioo_vector:
+                    combined_for_feed = _weighted_blend(
+                        ioo_vector, IOO_BLEND_RATIO,
+                        behavior_emb, 1.0 - IOO_BLEND_RATIO,
+                    )
+                else:
+                    combined_for_feed = behavior_emb
+                emb_str = _embedding_to_pgvector(combined_for_feed)
 
                 location_filter = ""
                 location_params = []
@@ -540,7 +560,8 @@ class RecommendationEngine:
                     avg_r = float(row["avg_rating"] or 0)
                     age = float(row["age_days"] or 30)
                     recency = max(0, 1.0 - age / 30.0)  # 1.0 for brand new, 0.0 for 30+ days
-                    score = sim * 0.6 + (avg_r / 5.0) * 0.3 + recency * 0.1
+                    ioo_bonus = 0.05 if ioo_vector else 0.0
+                    score = sim * 0.6 + (avg_r / 5.0) * 0.3 + recency * 0.1 + ioo_bonus
                     scored.append((card_id, score))
 
                 scored.sort(key=lambda x: x[1], reverse=True)

--- a/scripts/run_ioo_enrichment.py
+++ b/scripts/run_ioo_enrichment.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Run the daily IOO graph enrichment agent."""
+
+import asyncio
+import json
+import logging
+
+from core.database import close_pool, run_migrations
+from ora.agents.ioo_enrichment_agent import get_ioo_enrichment_agent
+
+logging.basicConfig(level=logging.INFO)
+
+
+async def main() -> None:
+    await run_migrations()
+    try:
+        result = await get_ioo_enrichment_agent().run_daily()
+        print(json.dumps(result, default=str))
+    finally:
+        await close_pool()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- Set up IOO node/user embeddings with pgvector + OpenAI fallback and blend IOO fingerprints into feed recommendations
- Add GPS-style IOO pathfinding with digital/physical preferences, prerequisite eligibility checks, dynamic bridge-node spawning, and personalised paths
- Add daily IOO enrichment agent, proposals review/approve endpoints, cron job script, and XP rewards for completed IOO nodes

## Endpoints
- GET /api/ioo/path?goal_id=...&preference=mixed|prefer_digital|prefer_physical
- GET /api/ioo/eligibility/{node_id}
- GET /api/ioo/proposals
- POST /api/ioo/proposals/{id}/approve
- POST /api/ioo/enrich
- GET /api/ioo/vector and /api/ioo/vector-recommend

## Verification
- python3 -m py_compile api/routes/ioo.py api/routes/gamification.py ora/agents/ioo_graph_agent.py ora/agents/ioo_enrichment_agent.py ora/agents/recommendation_engine.py core/database.py scripts/run_ioo_enrichment.py
- git diff --check
- Railway OPENAI_API_KEY set and verified masked
- Cron added: IOO graph enrichment — daily, 3am America/Vancouver