### PR TITLE
feat: add dynamic XP rewards and perks

### DIFF
--- a/api/routes/dao_rewards.py
+++ b/api/routes/dao_rewards.py
@@ -159,6 +159,14 @@ async def _get_or_create_user_cp(user_id: UUID) -> dict:
 
 async def _award_cp(user_id: UUID, amount: int, reason: str, reference: Optional[str] = None) -> dict:
     """Credit CP to a user and log the transaction."""
+    base_amount = amount
+    sovereign_bonus = 0
+    user_tier = await fetchval("SELECT subscription_tier FROM users WHERE id = $1", user_id)
+    if user_tier == "sovereign":
+        sovereign_bonus = int(amount * 0.1)
+        amount += sovereign_bonus
+        reason = f"{reason} | sovereign_bonus={sovereign_bonus}"
+
     # Update balance
     await execute(
         """
@@ -188,6 +196,8 @@ async def _award_cp(user_id: UUID, amount: int, reason: str, reference: Optional
     )
     return {
         "cp_awarded": amount,
+        "base_cp_awarded": base_amount,
+        "sovereign_bonus": sovereign_bonus,
         "new_balance": int(row["cp_balance"]),
         "total_earned": int(row["total_cp_earned"]),
     }

--- a/api/routes/gamification.py
+++ b/api/routes/gamification.py
@@ -18,12 +18,13 @@ Endpoints:
 """
 
 import logging
+import math
 from datetime import date, datetime, timezone
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from api.middleware import get_current_user_id
 from core.database import execute, fetch, fetchrow, fetchval
@@ -73,6 +74,7 @@ BADGE_DEFS = [
 class CheckinRequest(BaseModel):
     reason: str = "daily_login"   # context for XP award
     ref_id: Optional[str] = None
+    context: Dict[str, Any] = Field(default_factory=dict)
 
 class CollectionCreate(BaseModel):
     name: str
@@ -89,19 +91,99 @@ class CollectionItemAdd(BaseModel):
 
 # ─── Helpers ─────────────────────────────────────────────────────────────────
 
-async def _award_xp(user_id: str, reason: str, ref_id: Optional[str] = None) -> int:
-    """Award XP for a reason. Returns amount awarded (0 if unknown reason)."""
-    amount = XP_TABLE.get(reason, 0)
-    if amount <= 0:
+TIER_MULTIPLIERS = {"free": 1.0, "explorer": 1.5, "sovereign": 2.5}
+
+
+def xp_to_level(total_xp: int) -> int:
+    """XP required for each level follows exponential growth."""
+    if total_xp < 200:
+        return 1
+    return min(100, int(1 + math.log(total_xp / 100, 1.5)))
+
+
+def xp_for_level(level: int) -> int:
+    """XP needed to reach this level."""
+    if level <= 1:
         return 0
+    return int(100 * (1.5 ** (level - 1)))
+
+
+def _tier_multiplier(tier: str) -> float:
+    return TIER_MULTIPLIERS.get((tier or "free").lower(), 1.0)
+
+
+def _streak_multiplier(streak: int) -> float:
+    if streak >= 30:
+        return 1.5
+    if streak >= 7:
+        return 1.2
+    if streak >= 3:
+        return 1.1
+    return 1.0
+
+
+async def _current_xp_multiplier(user_id: str) -> Dict[str, Any]:
+    """Return the user's active base multiplier from tier + streak."""
+    user_row = await fetchrow(
+        "SELECT subscription_tier, streak_current FROM users WHERE id = $1",
+        UUID(user_id),
+    )
+    data = dict(user_row) if user_row else {}
+    tier = (data.get("subscription_tier") or "free").lower()
+    streak = int(data.get("streak_current") or 0)
+    multiplier = _tier_multiplier(tier) * _streak_multiplier(streak)
+    return {"tier": tier, "streak": streak, "multiplier": multiplier}
+
+
+async def _award_xp(
+    user_id: str,
+    reason: str,
+    ref_id: Optional[str] = None,
+    context: Optional[Dict[str, Any]] = None,
+) -> int:
+    """Award dynamically calculated XP for a reason. Returns amount awarded."""
+    base = XP_TABLE.get(reason, 0)
+    if base <= 0:
+        return 0
+
+    context = context or {}
+
     try:
+        multiplier_info = await _current_xp_multiplier(user_id)
+        multiplier = float(multiplier_info["multiplier"])
+
+        first_time = await fetchval(
+            "SELECT COUNT(*) FROM xp_log WHERE user_id = $1 AND reason = $2",
+            UUID(user_id), reason,
+        )
+        if int(first_time or 0) == 0:
+            multiplier *= 2.0
+
+        if reason == "ioo_node_complete":
+            difficulty = int(context.get("difficulty_level", 5) or 5)
+            difficulty = max(1, min(10, difficulty))
+            multiplier *= 0.5 + difficulty / 10.0
+
+        amount = max(1, int(base * multiplier))
+        ref_value = None
+        if ref_id:
+            ref_text = str(ref_id)
+            ref_value = str(UUID(ref_text)) if len(ref_text) == 36 else ref_text
+
         await execute(
             "INSERT INTO xp_log (user_id, amount, reason, ref_id) VALUES ($1, $2, $3, $4)",
-            UUID(user_id), amount, reason, ref_id,
+            UUID(user_id), amount, reason, ref_value,
         )
+
+        total_xp = await _get_total_xp(user_id)
+        await execute(
+            "UPDATE users SET xp_level = $2 WHERE id = $1",
+            UUID(user_id), xp_to_level(total_xp),
+        )
+        return amount
     except Exception as e:
         logger.warning(f"XP award failed: {e}")
-    return amount
+        return 0
 
 
 async def _get_total_xp(user_id: str) -> int:
@@ -222,6 +304,7 @@ async def _update_streak(user_id: str) -> Dict[str, Any]:
                 """,
                 UUID(user_id), today,
             )
+            await execute("UPDATE users SET streak_current = 1 WHERE id = $1", UUID(user_id))
             return {"current_streak": 1, "longest_streak": 1, "is_new_day": True, "streak_extended": True}
 
         last = row["last_activity_date"]
@@ -253,6 +336,7 @@ async def _update_streak(user_id: str) -> Dict[str, Any]:
                 """,
                 new_streak, today, UUID(user_id),
             )
+            await execute("UPDATE users SET streak_current = $2 WHERE id = $1", UUID(user_id), new_streak)
             return {
                 "current_streak": new_streak,
                 "longest_streak": max(longest, new_streak),
@@ -279,6 +363,7 @@ async def _update_streak(user_id: str) -> Dict[str, Any]:
             """,
             new_streak, new_longest, today, UUID(user_id),
         )
+        await execute("UPDATE users SET streak_current = $2 WHERE id = $1", UUID(user_id), new_streak)
 
         return {
             "current_streak": new_streak,
@@ -320,6 +405,13 @@ async def get_gamification_status(user_id: str = Depends(get_current_user_id)):
         last_date = streak_row["last_activity_date"] if streak_row else None
 
         total_xp = await _get_total_xp(user_id)
+        level = xp_to_level(total_xp)
+        current_level_xp = xp_for_level(level)
+        next_level_xp = xp_for_level(level + 1)
+        level_span = max(1, next_level_xp - current_level_xp)
+        xp_progress_pct = max(0, min(100, int(((total_xp - current_level_xp) / level_span) * 100)))
+        multiplier_info = await _current_xp_multiplier(user_id)
+        tier = multiplier_info["tier"]
 
         badges = await fetch(
             "SELECT badge_key, badge_name, badge_emoji, earned_at FROM user_badges WHERE user_id = $1 ORDER BY earned_at DESC",
@@ -348,6 +440,11 @@ async def get_gamification_status(user_id: str = Depends(get_current_user_id)):
                 "total": total_xp,
                 "next_milestone": next_milestone,
                 "progress_to_next": (total_xp / next_milestone) if next_milestone else 1.0,
+                "level": level,
+                "xp_for_next_level": next_level_xp,
+                "xp_progress_pct": xp_progress_pct,
+                "multiplier": round(float(multiplier_info["multiplier"]), 2),
+                "tier_bonus": "2.5x XP" if tier == "sovereign" else "1.5x XP" if tier == "explorer" else None,
             },
             "badges": [
                 {
@@ -359,15 +456,34 @@ async def get_gamification_status(user_id: str = Depends(get_current_user_id)):
                 for b in badges
             ],
             "collections_count": int(collection_count),
+            "level": level,
+            "xp_for_next_level": next_level_xp,
+            "xp_progress_pct": xp_progress_pct,
+            "multiplier": round(float(multiplier_info["multiplier"]), 2),
+            "tier_bonus": "2.5x XP" if tier == "sovereign" else "1.5x XP" if tier == "explorer" else None,
         }
 
     except Exception as e:
         logger.error(f"Gamification status error: {e}")
         return {
             "streak": {"current": 0, "longest": 0, "at_risk": False, "last_activity": None},
-            "xp": {"total": 0, "next_milestone": 100, "progress_to_next": 0},
+            "xp": {
+                "total": 0,
+                "next_milestone": 100,
+                "progress_to_next": 0,
+                "level": 1,
+                "xp_for_next_level": xp_for_level(2),
+                "xp_progress_pct": 0,
+                "multiplier": 1.0,
+                "tier_bonus": None,
+            },
             "badges": [],
             "collections_count": 0,
+            "level": 1,
+            "xp_for_next_level": xp_for_level(2),
+            "xp_progress_pct": 0,
+            "multiplier": 1.0,
+            "tier_bonus": None,
         }
 
 
@@ -399,7 +515,7 @@ async def daily_checkin(
 
     # Award XP for the triggering action (if different from login)
     if body.reason != "daily_login":
-        xp_awarded += await _award_xp(user_id, body.reason, body.ref_id)
+        xp_awarded += await _award_xp(user_id, body.reason, body.ref_id, body.context)
 
     # Check and award badges
     new_badges = await _check_and_award_badges(user_id)

--- a/api/routes/perks.py
+++ b/api/routes/perks.py
@@ -1,0 +1,108 @@
+"""
+Subscriber perk unlocks — what users get at different XP levels.
+Free users get taste of perks to encourage upgrade.
+"""
+from typing import Any, Dict, List
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+
+from api.middleware import get_current_user_id
+from api.routes.gamification import xp_for_level, xp_to_level
+from core.database import fetchrow, fetchval
+
+router = APIRouter(prefix="/api/perks", tags=["perks"])
+
+LEVEL_PERKS = {
+    "level_5_feed_unlock":     (5,  "free",       "Unlock 5 extra feed cards/day"),
+    "level_10_streak_shield":  (10, "free",       "Unlock 1 Streak Shield — protect your streak for 1 miss"),
+    "level_15_ioo_filter":     (15, "free",       "Unlock IOO difficulty filter in feed"),
+    "level_20_ora_memory":     (20, "free",       "Ora remembers your preferences more deeply"),
+    "explorer_daily_cards":    (1,  "explorer",   "50 feed cards/day (vs 10 free)"),
+    "explorer_xp_boost":       (1,  "explorer",   "1.5x XP on everything"),
+    "explorer_goal_coaching":  (5,  "explorer",   "Unlock deep goal coaching sessions with Ora"),
+    "explorer_level_rewards":  (10, "explorer",   "Monthly bonus XP drops based on activity"),
+    "sovereign_unlimited":     (1,  "sovereign",  "Unlimited feed cards"),
+    "sovereign_xp_boost":      (1,  "sovereign",  "2.5x XP on everything"),
+    "sovereign_priority_ora":  (1,  "sovereign",  "Priority Ora responses + longer context"),
+    "sovereign_exclusive_ioo": (5,  "sovereign",  "Access exclusive high-difficulty IOO nodes"),
+    "sovereign_early_access":  (1,  "sovereign",  "Early access to every new feature"),
+    "sovereign_cp_bonus":      (10, "sovereign",  "10% bonus CP on all DAO contributions"),
+}
+
+TIER_RANK = {"free": 0, "explorer": 1, "sovereign": 2}
+
+
+def _tier_meets(user_tier: str, required_tier: str) -> bool:
+    return TIER_RANK.get(user_tier or "free", 0) >= TIER_RANK.get(required_tier or "free", 0)
+
+
+def _perk_payload(perk_id: str, min_level: int, tier_required: str, description: str, total_xp: int) -> Dict[str, Any]:
+    required_xp = xp_for_level(min_level)
+    return {
+        "id": perk_id,
+        "min_level": min_level,
+        "tier_required": tier_required,
+        "description": description,
+        "xp_required": required_xp,
+        "xp_remaining": max(0, required_xp - total_xp),
+    }
+
+
+async def _user_progress(user_id: str) -> Dict[str, Any]:
+    total_xp = await fetchval(
+        "SELECT COALESCE(SUM(amount), 0) FROM xp_log WHERE user_id = $1",
+        UUID(user_id),
+    )
+    user_row = await fetchrow(
+        "SELECT subscription_tier FROM users WHERE id = $1",
+        UUID(user_id),
+    )
+    total = int(total_xp or 0)
+    user_data = dict(user_row) if user_row else {}
+    tier = (user_data.get("subscription_tier") or "free").lower()
+    return {"total_xp": total, "level": xp_to_level(total), "subscription_tier": tier}
+
+
+@router.get("/my-perks")
+async def get_my_perks(user_id: str = Depends(get_current_user_id)):
+    """Return user's active perks and what they're close to unlocking."""
+    progress = await _user_progress(user_id)
+    total_xp = progress["total_xp"]
+    level = progress["level"]
+    tier = progress["subscription_tier"]
+
+    active: List[Dict[str, Any]] = []
+    almost_unlocked: List[Dict[str, Any]] = []
+    upgrade_to_unlock: List[Dict[str, Any]] = []
+
+    for perk_id, (min_level, tier_required, description) in LEVEL_PERKS.items():
+        perk = _perk_payload(perk_id, min_level, tier_required, description, total_xp)
+        tier_ok = _tier_meets(tier, tier_required)
+        level_ok = level >= min_level
+
+        if level_ok and tier_ok:
+            active.append(perk)
+        elif not tier_ok:
+            upgrade_to_unlock.append({**perk, "level_met": level_ok})
+        elif 0 < perk["xp_remaining"] <= 500:
+            almost_unlocked.append(perk)
+
+    return {
+        "user": progress,
+        "active_perks": active,
+        "almost_unlocked": almost_unlocked,
+        "upgrade_to_unlock": upgrade_to_unlock,
+    }
+
+
+@router.get("/all")
+async def get_all_perks():
+    """Full perk catalogue for marketing and upgrade CTAs."""
+    return {
+        "perks": [
+            _perk_payload(perk_id, min_level, tier_required, description, 0)
+            for perk_id, (min_level, tier_required, description) in LEVEL_PERKS.items()
+        ],
+        "tiers": ["free", "explorer", "sovereign"],
+    }

--- a/core/database.py
+++ b/core/database.py
@@ -96,6 +96,8 @@ async def run_migrations():
                 hashed_password TEXT,
                 embedding vector(1536),
                 subscription_tier VARCHAR(20) DEFAULT 'free',
+                streak_current INTEGER DEFAULT 0,
+                xp_level INTEGER DEFAULT 1,
                 fulfilment_score FLOAT DEFAULT 0.0,
                 profile JSONB DEFAULT '{}'
             )
@@ -113,6 +115,12 @@ async def run_migrations():
         """)
         await conn.execute("""
             ALTER TABLE users ADD COLUMN IF NOT EXISTS display_name TEXT
+        """)
+        await conn.execute("""
+            ALTER TABLE users ADD COLUMN IF NOT EXISTS streak_current INTEGER DEFAULT 0
+        """)
+        await conn.execute("""
+            ALTER TABLE users ADD COLUMN IF NOT EXISTS xp_level INTEGER DEFAULT 1
         """)
         await conn.execute("""
             CREATE INDEX IF NOT EXISTS idx_users_provider ON users(auth_provider, provider_id)

--- a/core/migrations.sql
+++ b/core/migrations.sql
@@ -17,9 +17,14 @@ CREATE TABLE IF NOT EXISTS users (
     hashed_password TEXT,
     embedding vector(1536),
     subscription_tier VARCHAR(20) DEFAULT 'free',
+    streak_current INTEGER DEFAULT 0,
+    xp_level INTEGER DEFAULT 1,
     fulfilment_score FLOAT DEFAULT 0.0,
     profile JSONB DEFAULT '{}'
 );
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS streak_current INTEGER DEFAULT 0;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS xp_level INTEGER DEFAULT 1;
 
 CREATE TABLE IF NOT EXISTS screen_specs (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/main.py
+++ b/main.py
@@ -54,6 +54,7 @@ from api.routes import ora_autonomy as ora_autonomy_routes
 from api.routes import onboarding as onboarding_routes
 from api.routes import surfaces as surfaces_routes
 from api.routes import gamification as gamification_routes
+from api.routes import perks as perks_routes
 from api.routes import leaderboard as leaderboard_routes
 from api.routes import friends as friends_routes
 from api.routes import social_auth as social_auth_routes
@@ -290,6 +291,7 @@ app.include_router(ora_autonomy_routes.router)
 app.include_router(onboarding_routes.router)
 app.include_router(surfaces_routes.router)
 app.include_router(gamification_routes.router)
+app.include_router(perks_routes.router)
 app.include_router(leaderboard_routes.router)
 app.include_router(friends_routes.router)
 app.include_router(social_auth_routes.router)

--- a/migrations/008_gamification.sql
+++ b/migrations/008_gamification.sql
@@ -1,6 +1,9 @@
 -- Migration 008: Gamification — Streaks, XP, Badges, Collections
 -- Implements Duolingo-style retention mechanics + Pinterest-style save collections
 
+ALTER TABLE users ADD COLUMN IF NOT EXISTS streak_current INTEGER DEFAULT 0;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS xp_level INTEGER DEFAULT 1;
+
 -- ─── Streaks ──────────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS user_streaks (
     id                  SERIAL PRIMARY KEY,


### PR DESCRIPTION
## Summary
- Add dynamic XP rewards with subscription, streak, first-time, and IOO difficulty multipliers
- Add XP level helpers and status response level/progress/multiplier metadata
- Add /api/perks catalogue and authenticated my-perks endpoint
- Add user streak_current/xp_level migrations and synchronize streak/xp level fields
- Apply 10% CP bonus for sovereign users

## Validation
- python3 -m py_compile api/routes/gamification.py api/routes/perks.py api/routes/dao_rewards.py main.py core/database.py
- git diff --check
- git diff --cached --check