### PR TITLE
fix: add GitHub OAuth settings to config (resolves 404 on callback)

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -37,6 +37,9 @@ class Settings(BaseSettings):
 
     # GitHub — for daily identity pack commits (backup redundancy)
     GITHUB_TOKEN: str = ""
+    GITHUB_CLIENT_ID: str = ""
+    GITHUB_CLIENT_SECRET: str = ""
+    GITHUB_REDIRECT_URI: str = "https://connectome-api-production.up.railway.app/api/auth/github/callback"
 
     # Railway — for Railway API access (redeploy, env var updates)
     RAILWAY_API_TOKEN: str = ""


### PR DESCRIPTION
settings.GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, GITHUB_REDIRECT_URI were not defined in config.py — causing AttributeError at runtime and 404 on the callback route.