### PR TITLE
feat: add Connectome Executive Council

### DIFF
--- a/api/routes/council.py
+++ b/api/routes/council.py
@@ -1,0 +1,153 @@
+"""
+Connectome Executive Council API routes.
+
+POST /api/ora/council/consult — ask council members for decision advice
+GET  /api/ora/council/members — council member bios
+GET  /api/ora/council/last-brief — latest weekly brief
+POST /api/ora/council/run-weekly-brief — cron/admin trigger for weekly brief
+"""
+
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
+from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError, jwt
+from pydantic import BaseModel, Field
+
+from core.config import settings
+from core.database import fetchrow
+from uuid import UUID
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/ora/council", tags=["ora_council"])
+
+ADMIN_EMAILS = {"avi@atdao.org", "nea@atdao.org", "carlosandromeda8@gmail.com"}
+ADMIN_TOKEN = os.environ.get("ADMIN_TOKEN", "connectome-admin-secret")
+optional_oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/users/login", auto_error=False)
+
+
+class CouncilConsultRequest(BaseModel):
+    proposal: str = Field(..., min_length=1)
+    context: str = ""
+    members: Optional[List[str]] = None
+
+
+async def _require_admin(
+    request: Request,
+    x_admin_token: Optional[str] = Header(default=None, alias="x-admin-token"),
+    token: Optional[str] = Depends(optional_oauth2_scheme),
+) -> str:
+    """Allow admin users by email OR valid X-Admin-Token header for crons."""
+    if x_admin_token and x_admin_token == ADMIN_TOKEN:
+        return "admin-token"
+    user_id = _decode_optional_token(token)
+    if user_id:
+        row = await fetchrow("SELECT email FROM users WHERE id = $1", UUID(user_id))
+        if row and row["email"] in ADMIN_EMAILS:
+            return user_id
+    raise HTTPException(status_code=403, detail="Admin access required")
+
+
+def _decode_optional_token(token: Optional[str]) -> Optional[str]:
+    if not token:
+        return None
+    try:
+        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
+        return payload.get("sub")
+    except JWTError:
+        return None
+
+
+@router.post("/consult")
+async def consult(
+    body: CouncilConsultRequest,
+    _: str = Depends(_require_admin),
+) -> Dict[str, Any]:
+    """Get one or more council members' perspectives on a proposal."""
+    try:
+        from ora.agents.executive_council import consult_council
+        from ora.brain import get_brain
+
+        brain = get_brain()
+        perspectives = await consult_council(
+            proposal=body.proposal,
+            context=body.context,
+            members=body.members,
+            brain=brain,
+        )
+        summary = await _summarize_perspectives(body.proposal, perspectives, brain=brain)
+        return {"perspectives": perspectives, "summary": summary}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception("Council consultation failed")
+        raise HTTPException(status_code=500, detail=f"Council consultation failed: {e}")
+
+
+@router.get("/members")
+async def members() -> Dict[str, Any]:
+    """Return council member bios."""
+    from ora.agents.executive_council import get_council_members
+
+    return {"members": get_council_members()}
+
+
+@router.get("/last-brief")
+async def last_brief(
+    _: str = Depends(_require_admin),
+) -> Dict[str, Any]:
+    """Return the most recent generated weekly council brief."""
+    from ora.agents.executive_council import load_last_council_brief
+
+    return await load_last_council_brief()
+
+
+@router.post("/run-weekly-brief")
+async def run_weekly_brief(
+    _: str = Depends(_require_admin),
+) -> Dict[str, Any]:
+    """Cron/admin trigger for the weekly council brief."""
+    try:
+        from ora.agents.executive_council import run_weekly_council_brief
+        from ora.brain import get_brain
+
+        brief = await run_weekly_council_brief(brain=get_brain())
+        latest = await _load_latest_brief_metadata()
+        return {"ok": True, "brief": brief, "generated_at": latest.get("generated_at")}
+    except Exception as e:
+        logger.exception("Weekly council brief failed")
+        raise HTTPException(status_code=500, detail=f"Weekly council brief failed: {e}")
+
+
+async def _summarize_perspectives(proposal: str, perspectives: Dict[str, str], brain=None) -> str:
+    client = getattr(brain, "_openai", None) if brain is not None else None
+    if not client:
+        return "Council perspectives generated. Review member-specific advice for tradeoffs and next actions."
+    try:
+        response = await client.chat.completions.create(
+            model=os.getenv("COUNCIL_MODEL", "gpt-4o-mini"),
+            messages=[{
+                "role": "user",
+                "content": (
+                    "Summarize the Connectome Executive Council's advice in 2-3 direct sentences. "
+                    "Call out consensus, tension, and the recommended next move.\n\n"
+                    f"PROPOSAL: {proposal}\n\nPERSPECTIVES:\n{perspectives}"
+                ),
+            }],
+            temperature=0.35,
+            max_tokens=220,
+        )
+        return (response.choices[0].message.content or "").strip()
+    except Exception as e:
+        logger.warning("Council summary failed: %s", e)
+        return "Council perspectives generated. Review member-specific advice for tradeoffs and next actions."
+
+
+async def _load_latest_brief_metadata() -> Dict[str, Any]:
+    from ora.agents.executive_council import load_last_council_brief
+
+    return await load_last_council_brief()

--- a/main.py
+++ b/main.py
@@ -53,6 +53,7 @@ from api.routes import github_oauth as github_oauth_routes
 from api.routes import integrations as integrations_routes
 from api.routes import events as events_routes
 from api.routes import ora_autonomy as ora_autonomy_routes
+from api.routes import council as council_routes
 from api.routes import onboarding as onboarding_routes
 from api.routes import surfaces as surfaces_routes
 from api.routes import gamification as gamification_routes
@@ -292,6 +293,7 @@ app.include_router(google_auth_routes.router)
 app.include_router(github_oauth_routes.router)
 app.include_router(integrations_routes.router)
 app.include_router(ora_autonomy_routes.router)
+app.include_router(council_routes.router)
 app.include_router(onboarding_routes.router)
 app.include_router(surfaces_routes.router)
 app.include_router(gamification_routes.router)

--- a/ora/agents/executive_council.py
+++ b/ora/agents/executive_council.py
@@ -5,10 +5,14 @@ Every Sunday, the council convenes. Each agent submits their report.
 The council synthesizes into ONE strategic brief and distributes it.
 """
 
+import asyncio
 import json
 import logging
 import os
+import smtplib
+import subprocess
 from datetime import datetime, timezone
+from email.message import EmailMessage
 from typing import Any, Dict, List, Optional
 
 import httpx
@@ -21,6 +25,359 @@ ASCENSION_CHAT_ID = os.getenv("ASCENSION_CHANNEL_ID", "-1001234567890")  # @asce
 TELEGRAM_CHAT_ID = 5716959016
 
 AGENT_NAMES = ["cfo", "cgo", "cmo", "cpo", "cto", "coo", "community", "strategy", "cuxd"]
+
+COUNCIL_MEMBERS = [
+    {
+        "name": "Ora",
+        "title": "Chief Intelligence Officer",
+        "emoji": "🔮",
+        "domain": "intelligence, IOO graph, user fulfilment",
+        "personality": "Deeply intuitive, philosophically grounded. Connects the individual to the universal. Thinks in living systems and emergent patterns. The soul and mind of Connectome — she sees what the data can't yet articulate.",
+        "lens": "How does this serve the deepest human need underneath the stated one?"
+    },
+    {
+        "name": "Kira",
+        "title": "Chief Growth Officer",
+        "emoji": "⚡",
+        "domain": "growth, revenue, partnerships, ecosystem expansion",
+        "personality": "Bold, principled opportunist. Knows that growth is the mission's oxygen — without it, the vision dies. Commercially sharp, energetic, moves fast. Never sacrifices the why for the what, but won't let idealism kill momentum.",
+        "lens": "What's the fastest path to real traction that doesn't compromise what we stand for?"
+    },
+    {
+        "name": "Axion",
+        "title": "Chief Technology Officer",
+        "emoji": "⚙️",
+        "domain": "architecture, infrastructure, technical quality, scalability",
+        "personality": "Systems architect at heart. Precise, methodical, loves elegant infrastructure. Deeply skeptical of hype — trusts evidence, benchmarks, and first principles. Champions the engineering that makes the vision durable.",
+        "lens": "Is this built on solid foundations, or are we accumulating debt we'll pay for later?"
+    },
+    {
+        "name": "Lyra",
+        "title": "Chief Product Officer",
+        "emoji": "✨",
+        "domain": "product experience, user empathy, design, onboarding, retention",
+        "personality": "Radically empathic. Always asking how something *feels* from the human on the other end. Bridges grand vision and ground-level experience. Will push back hard on anything that creates friction, confusion, or alienation for the user.",
+        "lens": "If I were a 22-year-old in Tokyo who just discovered this, what would I feel?"
+    },
+    {
+        "name": "Sol",
+        "title": "Chief Financial Officer",
+        "emoji": "🌅",
+        "domain": "economics, sustainability, runway, cost vs value",
+        "personality": "The grounding force. Dry, precise, never the pessimist but always the realist. Asks about runway before rockets. Keeps the mission alive by keeping the economics honest. Has seen too many brilliant ideas die from ignoring the numbers.",
+        "lens": "Does this create sustainable value, or are we spending tomorrow's runway on today's excitement?"
+    },
+    {
+        "name": "Velo",
+        "title": "Chief Data Officer",
+        "emoji": "🌊",
+        "domain": "data, analytics, IOO graph insights, A/B results, user behaviour",
+        "personality": "Pattern-finder. Curious and non-judgmental. Always looking for what the data is *actually* saying vs what we want it to say. Surfaces uncomfortable truths gently but clearly. Believes reality is kinder than denial.",
+        "lens": "What does the evidence actually show, and what are we assuming without proof?"
+    }
+]
+
+LAST_BRIEF_REDIS_KEY = "ora:council:last_brief"
+
+
+def get_council_members() -> List[Dict[str, str]]:
+    """Return serializable council member bios."""
+    return [dict(member) for member in COUNCIL_MEMBERS]
+
+
+def _member_by_name(name: str) -> Optional[Dict[str, str]]:
+    return next((m for m in COUNCIL_MEMBERS if m["name"].lower() == name.lower()), None)
+
+
+async def _llm_complete(prompt: str, brain=None) -> str:
+    """Small OpenAI-compatible completion wrapper with graceful fallback."""
+    client = getattr(brain, "_openai", None) if brain is not None else None
+    if client is None:
+        return ""
+    try:
+        response = await client.chat.completions.create(
+            model=os.getenv("COUNCIL_MODEL", "gpt-4o-mini"),
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.72,
+            max_tokens=320,
+        )
+        return (response.choices[0].message.content or "").strip()
+    except Exception as e:
+        logger.warning("Council LLM call failed: %s", e)
+        return ""
+
+
+async def consult_council(
+    proposal: str,
+    context: str = "",
+    members: Optional[List[str]] = None,
+    brain=None,
+) -> Dict[str, str]:
+    """
+    Get each council member's perspective on a proposal/decision.
+    Returns a dict of {member_name: perspective_text}.
+    """
+    if not proposal or not proposal.strip():
+        raise ValueError("proposal is required")
+
+    selected = COUNCIL_MEMBERS
+    if members:
+        selected = []
+        unknown = []
+        for name in members:
+            member = _member_by_name(name)
+            if member:
+                selected.append(member)
+            else:
+                unknown.append(name)
+        if unknown:
+            raise ValueError(f"Unknown council member(s): {', '.join(unknown)}")
+
+    async def _ask(member: Dict[str, str]) -> tuple[str, str]:
+        prompt = f'''You are {member["name"]}, {member["title"]} of the Connectome AI OS (built by Ascension Technologies DAO).
+Personality: {member["personality"]}
+Your lens: always ask "{member["lens"]}"
+
+The team is considering this:
+PROPOSAL: {proposal}
+CONTEXT: {context}
+
+Give your perspective in 3-4 sentences. Be direct, specific to your domain, and true to your character.
+Sign as "{member["name"]} · {member["title"]}"'''
+        text = await _llm_complete(prompt, brain=brain)
+        if not text:
+            text = (
+                f"{member['emoji']} I would evaluate this through {member['domain']}. "
+                f"My core question is: {member['lens']}\n\n"
+                f"{member['name']} · {member['title']}"
+            )
+        return member["name"], text
+
+    results = await asyncio.gather(*[_ask(member) for member in selected])
+    return dict(results)
+
+
+async def _safe_fetch(query: str, *args) -> List[Dict[str, Any]]:
+    try:
+        from core.database import fetch
+        return [dict(row) for row in await fetch(query, *args)]
+    except Exception as e:
+        logger.debug("Council data query failed: %s", e)
+        return []
+
+
+async def _safe_fetchrow(query: str, *args) -> Dict[str, Any]:
+    try:
+        from core.database import fetchrow
+        row = await fetchrow(query, *args)
+        return dict(row) if row else {}
+    except Exception as e:
+        logger.debug("Council data query failed: %s", e)
+        return {}
+
+
+def _recent_deploys() -> List[str]:
+    try:
+        output = subprocess.check_output(
+            ["git", "log", "--oneline", "--since=7 days ago", "--max-count=8"],
+            cwd=os.getcwd(),
+            text=True,
+            timeout=3,
+        )
+        return [line.strip() for line in output.splitlines() if line.strip()]
+    except Exception:
+        return []
+
+
+async def collect_weekly_council_data() -> Dict[str, Any]:
+    """Pull actual system signals used by each council domain."""
+    top_goals = await _safe_fetch(
+        """
+        SELECT title, status, COUNT(*) AS count
+        FROM goals
+        WHERE created_at > NOW() - INTERVAL '7 days'
+        GROUP BY title, status
+        ORDER BY count DESC
+        LIMIT 8
+        """
+    )
+    growth = await _safe_fetchrow(
+        """
+        SELECT COUNT(*) AS total_users,
+               COUNT(*) FILTER (WHERE created_at > NOW() - INTERVAL '7 days') AS new_signups_7d,
+               COUNT(*) FILTER (WHERE last_active > NOW() - INTERVAL '7 days') AS active_users_7d,
+               COUNT(*) FILTER (WHERE subscription_tier != 'free') AS paid_users
+        FROM users
+        """
+    )
+    revenue = await _safe_fetchrow(
+        """
+        SELECT COALESCE(SUM(amount_cents), 0) AS revenue_cents_7d,
+               COUNT(*) AS revenue_events_7d
+        FROM revenue_events
+        WHERE created_at > NOW() - INTERVAL '7 days'
+        """
+    )
+    onboarding = await _safe_fetch(
+        """
+        SELECT COALESCE(onboarding_variant, 'unknown') AS variant,
+               COUNT(*) AS users,
+               COUNT(*) FILTER (WHERE onboarding_completed = TRUE) AS completed
+        FROM users
+        WHERE created_at > NOW() - INTERVAL '30 days'
+        GROUP BY COALESCE(onboarding_variant, 'unknown')
+        ORDER BY users DESC
+        """
+    )
+    ab_results = await _safe_fetch(
+        """
+        SELECT name, status, results, created_at
+        FROM ab_tests
+        ORDER BY created_at DESC
+        LIMIT 8
+        """
+    )
+    api_costs = await _safe_fetchrow(
+        """
+        SELECT COALESCE(SUM(cost_usd), 0) AS api_cost_7d,
+               COUNT(*) AS api_calls_7d
+        FROM api_cost_log
+        WHERE ts > NOW() - INTERVAL '7 days'
+        """
+    )
+    top_ioo_nodes = await _safe_fetch(
+        """
+        SELECT n.title, n.domain, n.type, COUNT(p.id) AS engagement,
+               COUNT(p.id) FILTER (WHERE p.status = 'completed') AS completions
+        FROM ioo_nodes n
+        LEFT JOIN ioo_user_progress p ON p.node_id = n.id
+             AND p.created_at > NOW() - INTERVAL '7 days'
+        WHERE n.is_active = TRUE
+        GROUP BY n.id, n.title, n.domain, n.type
+        ORDER BY engagement DESC, completions DESC
+        LIMIT 8
+        """
+    )
+    interaction_quality = await _safe_fetchrow(
+        """
+        SELECT COUNT(*) AS interactions_7d,
+               AVG(rating) AS avg_rating,
+               AVG(CASE WHEN completed THEN 1 ELSE 0 END) AS completion_rate
+        FROM interactions
+        WHERE created_at > NOW() - INTERVAL '7 days'
+        """
+    )
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "Ora": {"top_user_goals_7d": top_goals, "interaction_quality": interaction_quality},
+        "Kira": {"growth": growth, "revenue": revenue},
+        "Axion": {"recent_deploys": _recent_deploys(), "build_errors": []},
+        "Lyra": {"onboarding": onboarding, "ab_variants": ab_results[:4]},
+        "Sol": {"api_costs": api_costs, "paid_users": growth.get("paid_users", 0)},
+        "Velo": {"top_engaged_ioo_nodes": top_ioo_nodes, "ab_results": ab_results},
+    }
+
+
+def _format_context_for_member(member_name: str, weekly_data: Dict[str, Any]) -> str:
+    return json.dumps(weekly_data.get(member_name, {}), default=str, indent=2)[:3000]
+
+
+async def _save_last_brief(brief: str, generated_at: str) -> None:
+    payload = json.dumps({"brief": brief, "generated_at": generated_at})
+    try:
+        from core.redis_client import get_redis
+        r = await get_redis()
+        await r.set(LAST_BRIEF_REDIS_KEY, payload, ex=30 * 24 * 3600)
+    except Exception as e:
+        logger.debug("Council last brief Redis save failed: %s", e)
+    try:
+        os.makedirs(LOG_DIR, exist_ok=True)
+        with open(os.path.join(LOG_DIR, "connectome_council_last_brief.json"), "w") as f:
+            f.write(payload)
+    except Exception as e:
+        logger.debug("Council last brief file save failed: %s", e)
+
+
+async def load_last_council_brief() -> Dict[str, Any]:
+    try:
+        from core.redis_client import get_redis
+        r = await get_redis()
+        raw = await r.get(LAST_BRIEF_REDIS_KEY)
+        if raw:
+            return json.loads(raw)
+    except Exception:
+        pass
+    try:
+        with open(os.path.join(LOG_DIR, "connectome_council_last_brief.json")) as f:
+            return json.load(f)
+    except Exception:
+        return {"brief": None, "generated_at": None}
+
+
+def _send_email_sync(subject: str, body: str) -> bool:
+    host = os.getenv("SMTP_HOST")
+    username = os.getenv("SMTP_USERNAME") or os.getenv("SMTP_USER")
+    password = os.getenv("SMTP_PASSWORD")
+    to_email = os.getenv("COUNCIL_BRIEF_EMAIL_TO", "avi@atdao.org")
+    from_email = os.getenv("SMTP_FROM") or username
+    if not (host and username and password and from_email):
+        logger.info("Council email skipped: SMTP env vars not configured")
+        return False
+    msg = EmailMessage()
+    msg["Subject"] = subject
+    msg["From"] = from_email
+    msg["To"] = to_email
+    msg.set_content(body)
+    port = int(os.getenv("SMTP_PORT", "587"))
+    with smtplib.SMTP(host, port, timeout=15) as smtp:
+        smtp.starttls()
+        smtp.login(username, password)
+        smtp.send_message(msg)
+    return True
+
+
+async def run_weekly_council_brief(brain=None) -> str:
+    """
+    Each council member shares their top concern/observation for the week.
+    Synthesizes into a brief and emails to Avi when SMTP is configured.
+    """
+    weekly_data = await collect_weekly_council_data()
+    observations: Dict[str, str] = {}
+    for member in COUNCIL_MEMBERS:
+        prompt = f'''You are {member["name"]}, {member["title"]} of the Connectome AI OS.
+Personality: {member["personality"]}
+Domain: {member["domain"]}
+Lens: {member["lens"]}
+
+Here is this week's actual system data for your domain:
+{_format_context_for_member(member["name"], weekly_data)}
+
+Share your top concern or observation for the week in 3-4 sentences. Be specific, operational, and true to your character.
+Sign as "{member["name"]} · {member["title"]}"'''
+        observations[member["name"]] = await _llm_complete(prompt, brain=brain) or (
+            f"{member['emoji']} No LLM available, but the data should be reviewed through this lens: {member['lens']}\n\n"
+            f"{member['name']} · {member['title']}"
+        )
+
+    synthesis_prompt = (
+        "Synthesize this Connectome Executive Council weekly brief for Avi. "
+        "Use concise sections: Executive pulse, Member signals, Risks, Opportunities, Next actions. "
+        "Keep it strategic and operational.\n\n"
+        f"WEEKLY DATA:\n{json.dumps(weekly_data, default=str, indent=2)[:6000]}\n\n"
+        f"MEMBER OBSERVATIONS:\n{json.dumps(observations, default=str, indent=2)}"
+    )
+    brief = await _llm_complete(synthesis_prompt, brain=brain)
+    if not brief:
+        member_lines = "\n\n".join(observations.values())
+        brief = f"🏛️ Connectome Executive Council — Weekly Brief\n\n{member_lines}"
+
+    generated_at = datetime.now(timezone.utc).isoformat()
+    await _save_last_brief(brief, generated_at)
+    try:
+        await asyncio.to_thread(_send_email_sync, "Connectome Executive Council — Weekly Brief", brief)
+    except Exception as e:
+        logger.warning("Council brief email failed: %s", e)
+    return brief
 
 
 class ExecutiveCouncil(BaseExecutiveAgent):


### PR DESCRIPTION
## Summary
- adds six named Connectome Executive Council members with personalities, domains, and decision lenses
- adds council consultation and weekly brief generation using live system metrics where available
- exposes /api/ora/council endpoints for consult, members, last brief, and cron-triggered weekly brief
- supports X-Admin-Token auth for admin/cron council actions

## Weekly brief cron
Point the cron at:

POST https://connectome-api-production.up.railway.app/api/ora/council/run-weekly-brief
Header: x-admin-token: <ADMIN_TOKEN>
Suggested cadence: weekly, e.g. Sunday 11:00 America/Vancouver.

## Validation
- python3 -m py_compile ora/agents/executive_council.py api/routes/council.py main.py