### PR TITLE
Fix DAO approve request model

### DIFF
--- a/api/routes/dao.py
+++ b/api/routes/dao.py
@@ -55,6 +55,11 @@ class VoteProposalRequest(BaseModel):
     vote: str  # "for" or "against"
 
 
+class ApproveContributionRequest(BaseModel):
+    cp_amount: int
+    admin_note: Optional[str] = None
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- define ApproveContributionRequest used by the DAO approval endpoint so the API can import cleanly

## Tests
- python3 -m py_compile api/routes/dao.py api/routes/gamification.py api/routes/users.py ora/agents/model_evolution.py main.py
- main import attempted but local environment is missing slowapi