### PR TITLE
docs: add developer contribution pathway

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing to Connectome Backend
+
+Connectome is the AI OS backend for Ora and the Ascension Technologies ecosystem. Contributions should make the system more useful, reliable, intelligent, or easier for other builders to extend.
+
+## Local setup
+
+```bash
+git clone https://github.com/AvielCarlos/connectome-backend.git
+cd connectome-backend
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env
+uvicorn main:app --reload
+```
+
+Useful checks before opening a PR:
+
+```bash
+python -m compileall api core ora main.py
+```
+
+If your change touches a route, include a short curl/example request in the PR description when possible.
+
+## How to pick work
+
+1. Browse open issues.
+2. Prefer issues labelled `good first issue`, `agent-dev`, `backend`, `ml-graph`, `growth`, or `docs`.
+3. Comment with your intended implementation before starting if the issue is large or ambiguous.
+4. Keep PRs focused. One clear improvement beats one sprawling branch.
+
+## Contribution categories
+
+- **Agent development** — Ora agents, IOO execution, context reasoning, search, recommendation, orchestration.
+- **Backend/API** — FastAPI routes, data models, auth, integrations, performance, reliability.
+- **Graph/ML** — pgvector, embeddings, IOO ontology, prerequisite inference, ranking models.
+- **DAO/contribution systems** — CP attribution, GitHub webhooks, rewards, leaderboards, governance primitives.
+- **Growth engineering** — onboarding metrics, referral loops, contributor analytics.
+- **Docs/devex** — setup, architecture guides, examples, issue quality, API docs.
+
+## CP rewards
+
+Contribution Points recognise meaningful work and help identify founding stewards of the ecosystem.
+
+| Work type | Typical CP |
+| --- | ---: |
+| Docs polish, small bug, test coverage | 25–75 |
+| Good first issue / small feature | 75–200 |
+| Production feature or agent improvement | 200–600 |
+| Major architecture, ML/graph, infra, security | 600–1,500+ |
+
+CP is awarded after review based on shipped impact, quality, maintainability, and mission alignment. If you believe your work deserves a specific CP range, include it in the PR description.
+
+## Pull request checklist
+
+- [ ] The PR has a clear title and short summary.
+- [ ] The change is scoped to one problem.
+- [ ] Local checks ran, or the reason they could not run is stated.
+- [ ] New config is documented in `.env.example` if needed.
+- [ ] User-facing/API behaviour is documented.
+- [ ] The PR mentions the related issue and expected CP category.
+
+## Review principles
+
+We value ambitious work, but the backend must remain understandable and operable. Prefer simple, observable systems. Add abstractions only when they make the next contributor faster.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,83 @@
+# Connectome Backend — AI OS for Human Flourishing
+
+Connectome is the nervous system of the Ascension Technologies ecosystem: an AI OS that turns goals, context, places, routines, reflections, and community signals into coordinated action for human flourishing.
+
+This backend is where Ora's brain, agent runtime, IOO Execution Protocol, contribution tracking, CP rewards, and graph intelligence come together.
+
+## Why builders should care
+
+Most AI products are chat boxes. Connectome is infrastructure for an agentic life OS:
+
+- **Agent developers** can build specialized Ora agents that reason over goals, context, venues, routines, feedback, and DAO signals.
+- **Backend and infra engineers** can harden a real FastAPI + PostgreSQL/pgvector + Redis system already deployed toward production.
+- **Graph and ML engineers** can improve the IOO ontology, embeddings, prerequisite inference, and recommendation loops.
+- **Product-minded developers** can ship features that immediately become part of the iDo/Ora daily experience.
+- **Open-source contributors** earn visible Contribution Points (CP), leaderboard recognition, and a path toward founding steward status in the Ascension DAO.
+
+## Architecture overview
+
+```text
+Connectome Backend
+├── FastAPI API surface          api/routes/*
+├── Ora agent brain              ora/agents/*
+├── IOO Execution Protocol       api/routes/ioo*.py + graph/embedding logic
+├── DAO + contribution layer     api/routes/dao*.py, github_webhook.py, leaderboard.py
+├── Persistence                  PostgreSQL, pgvector, Redis
+└── External integrations        GitHub OAuth/webhooks, Google, Stripe, Places, OpenAI/Anthropic
+```
+
+Key domains:
+
+- **Ora** — the brain: executive agents, coaching, context, discovery, growth, contribution recruitment.
+- **Connectome** — the AI OS / nervous system: APIs, memory, graph, execution protocol, surfaces.
+- **iDo** — the daily app experience where users interact with Ora.
+- **Ascension Technologies** — DAO, governance, Contribution Points, ownership/economic coordination layer.
+
+## Contribute and earn CP
+
+Connectome uses Contribution Points (CP) to recognise meaningful work. CP can support reputation, leaderboard placement, steward invitations, governance weight, and future ecosystem upside as the DAO matures.
+
+Typical CP ranges:
+
+| Contribution | CP range |
+| --- | ---: |
+| Small docs, bug triage, test fixes | 25–75 CP |
+| Good first issue / contained feature | 75–200 CP |
+| Agent, backend, or frontend feature | 200–600 CP |
+| ML/graph architecture, production infra, major systems | 600–1,500+ CP |
+
+Final CP is based on shipped impact, review quality, maintainability, and whether the work advances the mission.
+
+## Good first areas
+
+- Add or improve API documentation for existing routes.
+- Create tests around contribution, DAO rewards, IOO execution, or feedback flows.
+- Improve GitHub webhook ingestion and CP attribution.
+- Add object storage support for feedback screenshots.
+- Build live SearchAgent and UXSelectionAgent foundations for IOO execution.
+- Improve pgvector node embeddings and prerequisite inference.
+- Instrument developer onboarding analytics.
+
+## Local setup
+
+```bash
+git clone https://github.com/AvielCarlos/connectome-backend.git
+cd connectome-backend
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env
+uvicorn main:app --reload
+```
+
+For local development, PostgreSQL and Redis are recommended. Some integrations fall back to mocks or disabled modes when keys are missing.
+
+## Start contributing
+
+1. Read [`CONTRIBUTING.md`](CONTRIBUTING.md).
+2. Read [`docs/DEVELOPER_MISSION.md`](docs/DEVELOPER_MISSION.md).
+3. Pick an issue labelled `good first issue`, `agent-dev`, `backend`, `ml-graph`, `frontend`, or `growth`.
+4. Comment with your intended approach.
+5. Open a focused PR and include the CP category you believe applies.
+
+We are looking for builders who want to make AI useful in real human lives — not just impressive in demos.

--- a/docs/DEVELOPER_MISSION.md
+++ b/docs/DEVELOPER_MISSION.md
@@ -1,0 +1,58 @@
+# Developer Mission — Build the Nervous System for Human Flourishing
+
+Connectome is an attempt to move beyond apps that compete for attention and toward an AI OS that helps people live with more clarity, vitality, connection, and agency.
+
+The ecosystem has four layers:
+
+- **Ora** — the brain: agents that understand context, goals, routines, constraints, and opportunities.
+- **Connectome** — the nervous system: APIs, memory, graph intelligence, execution protocol, and integrations.
+- **iDo** — the daily surface: a WeChat-like app for action, discovery, reflection, services, and community.
+- **Ascension Technologies** — the DAO/governance layer: Contribution Points, recognition, stewardship, and eventual economic coordination.
+
+## What AI and agent developers can build here
+
+This is a live system for agentic AI infrastructure, not a toy benchmark.
+
+High-leverage work includes:
+
+- Context-aware Ora actions that adapt to each page, goal, and user state.
+- SearchAgent, UXSelectionAgent, and execution agents for the IOO Execution Protocol.
+- Graph embeddings that connect goals, prerequisites, venues, services, routines, and human needs.
+- Feedback loops where user behaviour and explicit feedback improve recommendations.
+- Multi-agent executive systems that help the ecosystem build itself responsibly.
+
+## Why this matters
+
+A useful AI OS should not merely answer questions. It should help people:
+
+- clarify what they actually want,
+- discover the next meaningful action,
+- coordinate support from agents and humans,
+- build healthier routines and relationships,
+- and participate in ecosystems where contribution is recognised.
+
+That is the practical definition of human flourishing we are building toward.
+
+## How contribution becomes status
+
+Contributors earn CP for shipped work. CP is a public signal of trust and impact. Over time it can support:
+
+- leaderboard recognition,
+- founding steward invitations,
+- governance influence,
+- access to higher-leverage work,
+- and potential economic upside as the DAO matures.
+
+We are especially looking for builders who can combine technical taste with mission seriousness: AI engineers, agent developers, product-minded frontend engineers, backend infra builders, graph/ML researchers, and growth engineers.
+
+## What good work looks like
+
+Good Connectome work is:
+
+- **Human-grounded** — it improves real decisions, routines, discovery, or wellbeing.
+- **Composable** — future agents and surfaces can build on it.
+- **Observable** — behaviour can be inspected, measured, and improved.
+- **Credible** — no hype when a simple implementation is enough.
+- **Stewardship-oriented** — it leaves the system healthier than it found it.
+
+Start with an issue, ship a focused PR, and help build the AI OS for human flourishing.


### PR DESCRIPTION
## Summary\n- add a mission-aligned README for backend contributors\n- add CONTRIBUTING with setup, CP ranges, and PR expectations\n- add a developer mission doc for AI/agent builders\n\n## Validation\n- Docs-only change; no build required.\n