### PR TITLE
Add IOO screen graph foundation

### DIFF
--- a/api/routes/screens.py
+++ b/api/routes/screens.py
@@ -105,17 +105,48 @@ def _ioo_node_to_screen_dict(node: dict) -> dict:
 
 async def _store_ioo_screen_spec(spec_dict: dict) -> str:
     """Persist an IOO-sourced screen spec in screen_specs and return its DB id."""
+    metadata = spec_dict.get("metadata", {}) or {}
+    node_id = metadata.get("node_id")
+    screen_role = metadata.get("screen_role") or "recommend"
+    node_uuid = None
+    if node_id:
+        try:
+            node_uuid = UUID(str(node_id))
+        except ValueError:
+            node_uuid = None
+
     row = await fetchrow(
         """
-        INSERT INTO screen_specs (spec, agent_type, domain)
-        VALUES ($1, $2, $3)
+        INSERT INTO screen_specs (spec, agent_type, domain, ioo_node_id, screen_role)
+        VALUES ($1, $2, $3, $4, $5)
         RETURNING id
         """,
         json.dumps(spec_dict),
         "IOOGraphAgent",
-        spec_dict.get("metadata", {}).get("domain"),
+        metadata.get("domain"),
+        node_uuid,
+        screen_role,
     )
-    return str(row["id"])
+    db_id = str(row["id"])
+
+    # TODO(ScreenGraph): generated IOO screens are pathway nodes, not throwaway
+    # UI. This initial edge attaches the screen to its source IOO node; future
+    # generation should also create leads_to/requires/clarifies/executes edges
+    # between neighbouring generated screens and execution runs.
+    if node_uuid:
+        try:
+            from ora.agents.screen_graph_agent import create_screen_edge
+
+            await create_screen_edge(
+                from_screen_id=db_id,
+                relation_type="belongs_to_ioo_node",
+                ioo_node_id=node_uuid,
+                evidence={"source": "screens._store_ioo_screen_spec", "screen_role": screen_role},
+            )
+        except Exception as err:
+            logger.debug("Screen graph edge creation skipped for screen %s: %s", db_id[:8], err)
+
+    return db_id
 
 
 _STATIC_FALLBACK_CARDS = [
@@ -198,6 +229,9 @@ async def _static_fallback_card(
     # TODO(IOO): when the user chooses "do now", trigger the IOO Execution
     # Protocol for this fallback action. "do later" should schedule/resurface,
     # and "not interested" should become a graph-learning signal/refinement.
+    # TODO(ScreenGraph): once fallback cards are mapped to IOO candidate nodes,
+    # create screen_graph_edges here too so Do Now / Do Later / Not Interested
+    # can adjust user-specific pathway weights instead of only aggregate ratings.
 
     try:
         db_id = await _store_ioo_screen_spec(spec_dict)
@@ -548,6 +582,10 @@ async def save_screen_for_later(
     Bookmark a screen so Ora resurfaces it in ~24 hours.
     Upserts an interaction row with saved=true.
     """
+    # TODO(ScreenGraph): treat this as the explicit "Do Later" graph-learning
+    # signal. Increase the relevant user-specific screen_graph_edges weight,
+    # connect this screen to its resurfacing/reminder screen, and avoid treating
+    # a save as either completion or rejection.
     try:
         screen_uuid = UUID(body.screen_spec_id)
     except ValueError:

--- a/core/database.py
+++ b/core/database.py
@@ -138,6 +138,40 @@ async def run_migrations():
                 created_at TIMESTAMP DEFAULT NOW()
             )
         """)
+        await conn.execute("""
+            ALTER TABLE screen_specs ADD COLUMN IF NOT EXISTS embedding vector(1536)
+        """)
+        await conn.execute("""
+            ALTER TABLE screen_specs ADD COLUMN IF NOT EXISTS ioo_node_id UUID
+        """)
+        await conn.execute("""
+            ALTER TABLE screen_specs ADD COLUMN IF NOT EXISTS screen_role TEXT
+        """)
+
+        # Screen Graph — durable generated-screen pathway edges between user
+        # state, IOO nodes, clarifying screens, and execution screens.
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS screen_graph_edges (
+                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                from_screen_id UUID,
+                to_screen_id UUID,
+                relation_type TEXT NOT NULL,
+                ioo_node_id UUID,
+                user_id UUID REFERENCES users(id),
+                weight FLOAT DEFAULT 1.0,
+                evidence JSONB DEFAULT '{}',
+                created_at TIMESTAMP DEFAULT NOW(),
+                updated_at TIMESTAMP DEFAULT NOW()
+            )
+        """)
+        await conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_screen_graph_edges_user
+            ON screen_graph_edges(user_id)
+        """)
+        await conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_screen_graph_edges_ioo
+            ON screen_graph_edges(ioo_node_id)
+        """)
 
         # Interactions table
         await conn.execute("""

--- a/docs/IOO_NEURAL_GRAPH.md
+++ b/docs/IOO_NEURAL_GRAPH.md
@@ -1,0 +1,86 @@
+# IOO Neural Graph + Screen Graph
+
+## Core model
+
+The IOO Graph is not a flat content taxonomy. It is a neural graph — a living neural network inside Ora's brain and nervous system.
+
+Each IOO node represents a possible activity, experience, sub-goal, goal, capability, or pathway in the user's life. Edges represent learned transitions: what tends to lead somewhere meaningful, what requires preparation, what clarifies intent, and what can be executed now.
+
+Ora should treat the graph as an embodied map of possibility, not as a menu of static pages.
+
+## Screen Graph
+
+Generated screens are durable pathway/interface nodes. A screen is not merely a UI page; it is an intermediary pathway node between:
+
+1. the user's current state, capabilities, constraints, preferences, and vector;
+2. the IOO possibilities available in Ora's graph;
+3. the execution layer that turns an option into action.
+
+A generated screen should be stored with its own embedding and graph relationships. The same underlying IOO node may produce many different screen nodes depending on user context, timing, domain, and presentation strategy.
+
+Important screen relationships:
+
+- `leads_to` — this screen naturally routes toward another screen or outcome.
+- `requires` — this screen depends on another condition, preparation, or prerequisite screen.
+- `clarifies` — this screen helps Ora gather user intent or missing state.
+- `executes` — this screen initiates a concrete action or IOO execution run.
+- `belongs_to_ioo_node` — this screen is an interface/pathway for a specific IOO node.
+
+## Option spindles: A → B
+
+When a user wants to move from point A to point B, Ora should not construct a single brittle path. It should construct multiple organic option-spindles: bundles of possible routes, each with different tradeoffs.
+
+Example pathway dimensions:
+
+- fastest route;
+- easiest route;
+- most fulfilling route;
+- lowest-cost route;
+- most growth-oriented route;
+- most social route;
+- most aligned with the user's current nervous system state.
+
+Each spindle can contain IOO nodes, generated screen nodes, clarifying screens, and execution steps. User behaviour continuously updates the ranking and weights of these routes.
+
+## User state → screen path → execution
+
+The intended loop is:
+
+1. Ora reads the user state/vector: goals, mood, capabilities, constraints, history, preferences.
+2. Ora proposes IOO possibilities and generates one or more screen pathway nodes.
+3. The user responds through explicit or implicit signals: Do Now, Do Later, Not Interested, dwell, skip, save, rate, execute.
+4. Ora updates both:
+   - the user vector; and
+   - the Screen → IOO → Execution graph relationship.
+5. Ora refines future option spindles from the new state.
+
+The screen is therefore both an interface and a learning event.
+
+## Domains as modules, not fixed destinations
+
+Apps/domains such as iVive, Eviva, and Aventi are domains of activity and reusable modules. They bend around the user's path.
+
+- iVive can contribute vitality actions to a mission pathway.
+- Eviva can turn contribution into meaning, reputation, and service.
+- Aventi can turn exploration into lived experience and discovery.
+
+The user's path chooses and recombines modules. The modules should not trap the user in rigid silos.
+
+## Ora's brain and nervous system
+
+The IOO Graph is part of Ora's brain: it models meaning, capability, possibility, and progression.
+
+The Screen Graph is part of Ora's nervous system: it senses which interfaces move a user toward fulfilment, which confuse them, which invite execution, and which should be suppressed.
+
+Together they form a feedback loop:
+
+```text
+user state/vector
+  → IOO possibility graph
+  → generated screen graph
+  → user action / feedback / execution
+  → updated user state + graph weights
+  → better option spindles
+```
+
+This is the foundation for Ora as an adaptive AI operating system for human flourishing.

--- a/ora/agents/screen_graph_agent.py
+++ b/ora/agents/screen_graph_agent.py
@@ -1,0 +1,198 @@
+"""Screen Graph agent foundation.
+
+Screens are durable pathway/interface nodes between user state, IOO
+possibilities, and execution. This module intentionally contains deterministic
+helpers only: no external LLM calls, no hidden generation side effects.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Iterable, Mapping, Optional
+from uuid import UUID
+
+from core.database import fetchrow
+
+SCREEN_RELATIONS = {
+    "leads_to",
+    "requires",
+    "clarifies",
+    "executes",
+    "belongs_to_ioo_node",
+}
+
+
+def _as_uuid(value: Any) -> Optional[UUID]:
+    """Return value as UUID when possible; otherwise None."""
+    if value in (None, ""):
+        return None
+    if isinstance(value, UUID):
+        return value
+    try:
+        return UUID(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _terms(value: Any) -> set[str]:
+    """Create a small deterministic term set for lightweight matching."""
+    if value is None:
+        return set()
+    if isinstance(value, Mapping):
+        chunks = [str(k) for k in value.keys()] + [str(v) for v in value.values()]
+    elif isinstance(value, (list, tuple, set)):
+        chunks = [str(v) for v in value]
+    else:
+        chunks = str(value).replace("_", " ").split()
+    return {chunk.strip().lower() for chunk in chunks if chunk and chunk.strip()}
+
+
+def _overlap_score(a: Any, b: Any) -> float:
+    """Return a deterministic 0..1 lexical overlap score."""
+    a_terms = _terms(a)
+    b_terms = _terms(b)
+    if not a_terms or not b_terms:
+        return 0.0
+    return len(a_terms & b_terms) / max(len(a_terms | b_terms), 1)
+
+
+async def create_screen_edge(
+    *,
+    from_screen_id: Any = None,
+    to_screen_id: Any = None,
+    relation_type: str,
+    ioo_node_id: Any = None,
+    user_id: Any = None,
+    weight: float = 1.0,
+    evidence: Optional[Mapping[str, Any]] = None,
+) -> Optional[dict]:
+    """Create or update a Screen Graph edge.
+
+    Edges connect generated screen specs to other screen specs and/or IOO nodes.
+    `from_screen_id` and `to_screen_id` are optional because some relations, such
+    as `belongs_to_ioo_node`, may initially only attach a screen to an IOO node.
+    Invalid relation types raise ValueError; invalid UUID-like identifiers are
+    stored as NULL rather than crashing the learning path.
+    """
+    if relation_type not in SCREEN_RELATIONS:
+        raise ValueError(f"Unsupported screen graph relation_type: {relation_type}")
+
+    safe_weight = max(0.0, min(float(weight), 10.0))
+    row = await fetchrow(
+        """
+        INSERT INTO screen_graph_edges (
+            from_screen_id, to_screen_id, relation_type, ioo_node_id,
+            user_id, weight, evidence, created_at, updated_at
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, NOW(), NOW())
+        RETURNING id, from_screen_id, to_screen_id, relation_type, ioo_node_id,
+                  user_id, weight, evidence, created_at, updated_at
+        """,
+        _as_uuid(from_screen_id),
+        _as_uuid(to_screen_id),
+        relation_type,
+        _as_uuid(ioo_node_id),
+        _as_uuid(user_id),
+        safe_weight,
+        json.dumps(dict(evidence or {})),
+    )
+    return dict(row) if row else None
+
+
+def propose_option_spindles(
+    user_state: Mapping[str, Any],
+    desired_outcome: Any,
+    candidate_nodes: Iterable[Mapping[str, Any]],
+) -> list[dict]:
+    """Propose multiple deterministic A→B route spindles.
+
+    The output is deliberately simple: each spindle groups candidate IOO nodes
+    around a route strategy. Runtime agents can later expand these into richer
+    graph searches and execution plans.
+    """
+    nodes = [dict(node) for node in candidate_nodes]
+    if not nodes:
+        return []
+
+    strategies = [
+        ("fastest", "requires_time_hours", False),
+        ("easiest", "difficulty_level", False),
+        ("growth", "difficulty_level", True),
+        ("best_fit", "semantic_fit", True),
+    ]
+    spindles: list[dict] = []
+    for name, key, reverse in strategies:
+        scored: list[tuple[float, dict]] = []
+        for node in nodes:
+            if key == "semantic_fit":
+                score = (
+                    _overlap_score(desired_outcome, node.get("title")) * 0.45
+                    + _overlap_score(desired_outcome, node.get("description")) * 0.25
+                    + _overlap_score(user_state.get("preferences"), node.get("tags")) * 0.20
+                    + _overlap_score(user_state.get("domain"), node.get("domain")) * 0.10
+                )
+            else:
+                raw = node.get(key)
+                score = float(raw if raw is not None else (999 if key == "requires_time_hours" else 5))
+            scored.append((score, node))
+
+        ranked = [node for _, node in sorted(scored, key=lambda item: item[0], reverse=reverse)]
+        selected = ranked[:5]
+        if selected:
+            spindles.append(
+                {
+                    "strategy": name,
+                    "desired_outcome": desired_outcome,
+                    "nodes": selected,
+                    "pathway_node_ids": [str(node.get("id")) for node in selected if node.get("id")],
+                    "confidence": round(0.45 + min(len(selected), 5) * 0.08, 2),
+                }
+            )
+    return spindles
+
+
+def rank_screen_pathways(
+    user_context: Mapping[str, Any],
+    ioo_nodes: Iterable[Mapping[str, Any]],
+    screen_candidates: Iterable[Mapping[str, Any]],
+) -> list[dict]:
+    """Rank generated screens as pathway nodes for the current user context.
+
+    The scorer favours screens connected to matching IOO nodes, user-preferred
+    domains/tags, explicit screen roles, and prior edge weight. It is stable and
+    explainable so UI/API code can use it before introducing heavier planning.
+    """
+    node_by_id = {str(node.get("id")): dict(node) for node in ioo_nodes if node.get("id")}
+    preferred_terms = _terms(user_context.get("preferences")) | _terms(user_context.get("domain"))
+    desired_terms = _terms(user_context.get("desired_outcome") or user_context.get("goal"))
+
+    ranked: list[dict] = []
+    for screen in screen_candidates:
+        candidate = dict(screen)
+        metadata = candidate.get("metadata") or {}
+        ioo_node_id = str(candidate.get("ioo_node_id") or metadata.get("node_id") or "")
+        node = node_by_id.get(ioo_node_id, {})
+
+        score = 0.0
+        score += _overlap_score(preferred_terms, candidate.get("domain") or metadata.get("domain")) * 0.20
+        score += _overlap_score(preferred_terms, metadata.get("tags") or candidate.get("tags")) * 0.20
+        score += _overlap_score(desired_terms, node.get("title")) * 0.20
+        score += _overlap_score(desired_terms, node.get("description")) * 0.15
+        score += min(float(candidate.get("edge_weight", 1.0) or 1.0), 10.0) / 10.0 * 0.15
+        if candidate.get("screen_role") in {"clarify", "execute", "recommend", "reflect"}:
+            score += 0.10
+
+        ranked.append(
+            {
+                **candidate,
+                "ioo_node": node or None,
+                "pathway_score": round(score, 4),
+                "ranking_evidence": {
+                    "matched_ioo_node_id": ioo_node_id or None,
+                    "screen_role": candidate.get("screen_role"),
+                    "edge_weight": candidate.get("edge_weight", 1.0),
+                },
+            }
+        )
+
+    return sorted(ranked, key=lambda item: item["pathway_score"], reverse=True)


### PR DESCRIPTION
## Summary\n- document IOO Neural Graph, Screen Graph, and option-spindle architecture\n- add initial screen_graph_edges schema plus screen_specs pathway columns\n- add deterministic screen graph agent helpers and route hooks for generated IOO screens / Do Later feedback\n\n## Validation\n- python3 -m py_compile core/database.py api/routes/screens.py ora/agents/screen_graph_agent.py