### PR TITLE
chore: route Drive API through cloud OAuth agent

### DIFF
--- a/api/routes/drive.py
+++ b/api/routes/drive.py
@@ -20,18 +20,24 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from api.middleware import get_current_user_id
 from core.database import fetchrow
 from ora.brain import get_brain
+from ora.agents.drive_agent_v2 import DriveAgentV2
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/drive", tags=["drive"])
 
 
 def _get_drive_agent():
-    """Return DriveAgent from the live Ora brain."""
+    """Return the cloud-safe DriveAgentV2.
+
+    The legacy DriveAgent depends on the local `gog` CLI and Avi's laptop
+    account. Production Drive routes must use OAuth-backed Google API access so
+    Connectome remains cloud-portable and user-scoped.
+    """
     try:
         brain = get_brain()
-        return brain.drive_agent
+        return DriveAgentV2(openai_client=getattr(brain, "_openai", None))
     except Exception as e:
-        logger.warning(f"Drive: could not get brain drive_agent: {e}")
+        logger.warning(f"Drive: could not initialize DriveAgentV2: {e}")
         return None
 
 
@@ -71,7 +77,7 @@ async def sync_drive(
         )
 
     try:
-        summary = await agent.sync(max_files=max_files, owner_user_id=user_id)
+        summary = await agent.sync(user_id=user_id, max_files=max_files)
         return {"ok": True, "sync": summary}
     except Exception as e:
         logger.error(f"Drive sync failed: {e}", exc_info=True)
@@ -96,7 +102,7 @@ async def search_drive(
     try:
         results = await agent.semantic_search(
             query=q,
-            owner_user_id=user_id,
+            user_id=user_id,
             limit=limit,
             min_similarity=min_similarity,
         )
@@ -119,7 +125,7 @@ async def drive_status(
         return {"ok": True, "indexed_documents": 0, "last_sync": None, "status": "agent_unavailable"}
 
     try:
-        stat = await agent.status(owner_user_id=user_id)
+        stat = await agent.status(user_id=user_id)
         return {"ok": True, **stat}
     except Exception as e:
         logger.warning(f"Drive status failed: {e}")

--- a/docs/cloud-migration.md
+++ b/docs/cloud-migration.md
@@ -17,6 +17,7 @@ Run Connectome backend safely in Railway/cloud without depending on Avi's laptop
 - Local `himalaya` email delivery replaced with SMTP env configuration.
 - OpenClaw cron CLI checks are opt-in via `OPENCLAW_CLI_ENABLED`.
 - Legacy `gog` Drive sync is skipped in production unless explicitly enabled via `GOG_CLI_ENABLED`.
+- `/api/drive/*` routes use OAuth-backed `DriveAgentV2` instead of the local `gog` CLI.
 - WebSpawn Railway CLI deploy fallback is dev-only; production requires Railway API IDs.
 - `.env.example`, `render.yaml`, `deploy.sh`, and `requirements.txt` updated.
 
@@ -37,7 +38,7 @@ Mandatory:
   - `FEEDBACK_SCREENSHOT_S3_ENDPOINT_URL`
   - `FEEDBACK_SCREENSHOT_S3_ACCESS_KEY_ID`
   - `FEEDBACK_SCREENSHOT_S3_SECRET_ACCESS_KEY`
-  - `FEEDBACK_SCREENSHOT_PUBLIC_BASE_URL`
+  - `FEEDBACK_SCREENSHOT_PUBLIC_BASE_URL` is optional; omit it for private ephemeral screenshot processing.
 
 If Stripe is enabled:
 
@@ -66,11 +67,9 @@ Recommended integrations:
 
 ## Avi involvement needed
 
-1. Approve generating/setting new production secrets in Railway.
-2. Choose S3/R2 provider for durable screenshot storage, or provide credentials.
-3. Confirm SMTP provider/account for customer delivery email.
-4. Confirm whether Stripe is live now; if yes, set webhook secret before deploy.
-5. Approve deployment after reviewing this branch diff.
+1. Confirm Cloudflare R2 lifecycle rule deletes leftover screenshot objects after 1 day.
+2. Verify Resend DNS for `atdao.org`, then rotate the Resend API key that was pasted in chat.
+3. Choose/provision the cloud host for OpenClaw Gateway so Nea's runtime can move off Avi's Mac.
 
 ## Verification gates
 
@@ -110,6 +109,7 @@ Expected callback status is `422`, not `404`.
 
 ## Remaining non-blocking follow-up
 
-- Replace legacy `DriveAgent`/`gog` flow fully with `DriveAgentV2` and Google API flows.
+- Retire the legacy `DriveAgent` object from `AuraBrain` after discovery/search paths are fully verified against `DriveAgentV2`.
 - Add cloud scheduler telemetry to replace local OpenClaw cron inspection.
+- Move OpenClaw Gateway to a Linux VPS/systemd host and keep the Mac as an optional node for macOS-only tools.
 - Consider making `/health` return non-200 when DB/Redis are degraded, or add a separate strict `/ready` endpoint for Railway.


### PR DESCRIPTION
## Summary\n- route /api/drive endpoints through OAuth-backed DriveAgentV2 instead of legacy local gog CLI agent\n- update cloud migration docs to reflect current Railway/R2/Resend state and remaining OpenClaw Gateway migration\n\n## Verification\n- python3 -m compileall -q api/routes/drive.py ora/agents/drive_agent_v2.py\n- git diff --check\n\n## Notes\nThis removes one more laptop-dependent production path. Legacy DriveAgent still exists in AuraBrain for compatibility, but API routes now use the cloud-safe user-scoped agent.