### PR TITLE
fix(events): require verified event location vectors

### DIFF
--- a/api/routes/events.py
+++ b/api/routes/events.py
@@ -15,6 +15,7 @@ Conveyor belt model:
   • starts_at > NOW() always — never return past events
 """
 
+import json
 import logging
 from datetime import datetime, timezone
 from typing import List, Optional
@@ -42,6 +43,7 @@ class EventCard(BaseModel):
     venue_name: Optional[str] = None
     address: Optional[str] = None
     city: Optional[str] = None
+    country: Optional[str] = None
     latitude: Optional[float] = None
     longitude: Optional[float] = None
     starts_at: Optional[datetime] = None
@@ -73,6 +75,7 @@ class SyncResponse(BaseModel):
 
 class LocationUpdate(BaseModel):
     city: str = Field(..., min_length=1, max_length=100, description="City name e.g. 'Vancouver'")
+    country: Optional[str] = Field(None, min_length=1, max_length=100)
     location_lat: Optional[float] = Field(None, ge=-90, le=90)
     location_lng: Optional[float] = Field(None, ge=-180, le=180)
     event_preferences: Optional[List[str]] = Field(
@@ -131,7 +134,7 @@ async def list_events(
     return EventListResponse(
         events=[EventCard(**ev) for ev in events],
         count=len(events),
-        city=city,
+        city=f"{city}, {country}" if country else city,
         days_ahead=days_ahead,
         window_start=now,
         window_end=until,
@@ -167,15 +170,24 @@ async def recommended_events(
     until = now + timedelta(days=days_ahead)
 
     user = await fetchrow(
-        "SELECT city FROM users WHERE id = $1", UUID(user_id)
+        """
+        SELECT COALESCE(NULLIF(s.location_city, ''), NULLIF(u.city, '')) AS city,
+               NULLIF(s.location_country, '') AS country,
+               u.location_lat, u.location_lng
+        FROM users u
+        LEFT JOIN ioo_user_state s ON s.user_id = u.id
+        WHERE u.id = $1
+        """,
+        UUID(user_id),
     )
-    if not user or not user.get("city"):
+    if not user or not user.get("city") or not user.get("country"):
         raise HTTPException(
             status_code=400,
-            detail="Set your city first via POST /api/users/location",
+            detail="Set your city/country first via live location or Travel Mode",
         )
 
     city = user["city"]
+    country = user.get("country")
 
     try:
         agent = EventAgent()
@@ -191,7 +203,7 @@ async def recommended_events(
     return EventListResponse(
         events=[EventCard(**ev) for ev in events],
         count=len(events),
-        city=city,
+        city=f"{city}, {country}" if country else city,
         days_ahead=days_ahead,
         window_start=now,
         window_end=until,
@@ -261,6 +273,15 @@ async def update_user_location(
         "event_preferences": ["wellness", "tech", "music"]
       }
     """
+    country = (body.country or "").strip()
+    if (not country) and body.location_lat is not None and body.location_lng is not None:
+        try:
+            from core.geo import reverse_geocode_lat_lng
+            geo = await reverse_geocode_lat_lng(body.location_lat, body.location_lng)
+            country = (geo or {}).get("country") or ""
+        except Exception:
+            country = ""
+
     try:
         await execute(
             """
@@ -277,6 +298,38 @@ async def update_user_location(
             body.event_preferences or [],
             UUID(user_id),
         )
+        await execute(
+            """
+            INSERT INTO ioo_user_state (user_id, location_city, location_country, state_json, last_updated)
+            VALUES ($1, $2, $3, $4::jsonb, NOW())
+            ON CONFLICT (user_id) DO UPDATE SET
+                location_city = EXCLUDED.location_city,
+                location_country = COALESCE(EXCLUDED.location_country, ioo_user_state.location_country),
+                state_json = COALESCE(ioo_user_state.state_json, '{}'::jsonb) || EXCLUDED.state_json,
+                last_updated = NOW()
+            """,
+            str(user_id),
+            body.city,
+            country or None,
+            json.dumps({
+                "location_lat": body.location_lat,
+                "location_lng": body.location_lng,
+                "geo_source": "manual_or_travel_location",
+            }),
+        )
+        try:
+            from ora.user_model import update_user_embedding_from_context
+            location_context = {
+                "location_city": body.city,
+                "location_country": country or None,
+                "location_lat": body.location_lat,
+                "location_lng": body.location_lng,
+                "location_source": "manual_or_travel_location",
+            }
+            await update_user_embedding_from_context(str(user_id), location_context, "now")
+            await update_user_embedding_from_context(str(user_id), location_context, "later")
+        except Exception as vec_e:
+            logger.debug(f"Manual/travel location user vector refresh skipped for {user_id[:8]}: {vec_e}")
     except Exception as e:
         logger.error(f"POST /api/users/location error: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Could not update location")
@@ -307,6 +360,7 @@ async def update_user_location(
     return {
         "status": "updated",
         "city": body.city,
+        "country": country or None,
         "location_lat": body.location_lat,
         "location_lng": body.location_lng,
         "event_preferences": body.event_preferences or [],
@@ -387,6 +441,19 @@ async def update_user_live_location(
             await get_graph_agent().build_user_ioo_vector(str(user_id))
         except Exception as e:
             logger.debug(f"Live location IOO vector refresh skipped for {user_id[:8]}: {e}")
+        try:
+            from ora.user_model import update_user_embedding_from_context
+            location_context = {
+                "location_city": city,
+                "location_country": country or None,
+                "location_lat": body.location_lat,
+                "location_lng": body.location_lng,
+                "location_source": "browser_gps",
+            }
+            await update_user_embedding_from_context(str(user_id), location_context, "now")
+            await update_user_embedding_from_context(str(user_id), location_context, "later")
+        except Exception as e:
+            logger.debug(f"Live location user vector refresh skipped for {user_id[:8]}: {e}")
     except Exception as e:
         logger.error(f"POST /api/users/location/live error: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Could not update live location")

--- a/api/routes/screens.py
+++ b/api/routes/screens.py
@@ -993,8 +993,13 @@ def _real_action_spec(item: dict[str, Any], *, source: str = "curated_real_actio
             "temporal_branch": "future_event" if feed_mode == "future" else "now_action",
             "starts_at": _serialise_dt(item.get("starts_at")) if item.get("starts_at") else None,
             "city": item.get("city"),
+            "country": item.get("country"),
             "location_city": item.get("city"),
-            "location_signal": f"city:{item.get('city')}" if item.get("city") else None,
+            "location_country": item.get("country"),
+            "latitude": item.get("latitude"),
+            "longitude": item.get("longitude"),
+            "location_verified": bool(item.get("latitude") is not None and item.get("longitude") is not None and item.get("city") and item.get("country")),
+            "location_signal": f"city_country:{item.get('city')},{item.get('country')} coords:{item.get('latitude')},{item.get('longitude')}" if item.get("city") else None,
             "opportunity_kind": item.get("kind"),
             "path_progression": _path_progression_metadata(kind="user_created_opportunity" if source == "user_created_opportunity" else "real_world_action", domain=domain, current_stage="confirm_micro_node"),
             "tags": [item.get("tag") or "real_action", "diversity_seed"],
@@ -1166,14 +1171,14 @@ async def _try_live_event_action(user_id: str, tier: str, daily_limit: int) -> O
         agent = EventAgent()
         city = await _user_city(user_id)
         events = await agent.get_recommended_events(user_id=str(user_id), days_ahead=14, limit=8)
-        events = [ev for ev in events if ev.get("url")]
+        events = [ev for ev in events if ev.get("url") and ev.get("latitude") is not None and ev.get("longitude") is not None and ev.get("city") and ev.get("country")]
         if not events and city:
             try:
                 await agent.sync_city(city, force=False)
             except Exception as sync_err:
                 logger.debug("Live event feed sync skipped for %s/%s: %s", str(user_id)[:8], city, sync_err)
             events = await agent.get_events_for_city(city=city, days_ahead=14, limit=8)
-            events = [ev for ev in events if ev.get("url")]
+            events = [ev for ev in events if ev.get("url") and ev.get("latitude") is not None and ev.get("longitude") is not None and ev.get("city") and ev.get("country")]
         if not events:
             return None
         event = events[0] if len(events) <= 2 else random.choice(events[: min(5, len(events))])
@@ -1187,6 +1192,11 @@ async def _try_live_event_action(user_id: str, tier: str, daily_limit: int) -> O
             "url": event.get("url"),
             "button": "Open event details →",
             "venue": event.get("venue_name") or event.get("address") or event.get("city"),
+            "city": event.get("city"),
+            "country": event.get("country"),
+            "latitude": event.get("latitude"),
+            "longitude": event.get("longitude"),
+            "map_url": f"https://www.google.com/maps/search/?api=1&query={event.get('latitude')},{event.get('longitude')}" if event.get("latitude") is not None and event.get("longitude") is not None else None,
             "starts_at": event.get("starts_at"),
             "price": event.get("price_range"),
             "steps": ["Open the event page.", "Check date, location, cost, and transport.", "Book, invite someone, or save it for later."],

--- a/core/database.py
+++ b/core/database.py
@@ -1375,6 +1375,7 @@ async def run_migrations():
                 venue_name TEXT,
                 address TEXT,
                 city VARCHAR(100),
+                country VARCHAR(100),
                 latitude FLOAT,
                 longitude FLOAT,
                 starts_at TIMESTAMPTZ,
@@ -1388,6 +1389,9 @@ async def run_migrations():
                 created_at TIMESTAMPTZ DEFAULT NOW(),
                 updated_at TIMESTAMPTZ DEFAULT NOW()
             )
+        """)
+        await conn.execute("""
+            ALTER TABLE events ADD COLUMN IF NOT EXISTS country VARCHAR(100)
         """)
         await conn.execute("""
             CREATE INDEX IF NOT EXISTS events_city_idx

--- a/core/geo.py
+++ b/core/geo.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 
 GEO_API_URL = "http://ip-api.com/json/{ip}?fields=status,city,regionName,country,countryCode,timezone,lat,lon"
 REVERSE_GEO_URL = "https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat={lat}&lon={lon}&zoom=10&addressdetails=1"
+FORWARD_GEO_URL = "https://nominatim.openstreetmap.org/search?format=jsonv2&q={query}&limit=1&addressdetails=1"
 CACHE_TTL_SECONDS = 86_400  # 24 hours
 
 
@@ -147,6 +148,70 @@ async def reverse_geocode_lat_lng(lat: float, lon: float) -> Optional[Dict[str, 
             return result
     except Exception as e:
         logger.debug(f"Reverse geo lookup failed for {lat_f},{lon_f}: {e}")
+        return None
+
+
+async def geocode_location_query(query: str) -> Optional[Dict[str, Any]]:
+    """Resolve an event venue/address/city query into city/country + coordinates.
+
+    Used conservatively for public event metadata. Cached by normalized query so
+    event syncs do not hammer the public geocoder. Returns None on ambiguity or
+    failure rather than fabricating a location.
+    """
+    text = " ".join(str(query or "").split())[:300]
+    if not text:
+        return None
+
+    cache_key = "geo:forward:" + text.lower()
+    try:
+        from core.redis_client import get_redis
+        r = await get_redis()
+        cached = await r.get(cache_key)
+        if cached:
+            return json.loads(cached)
+    except Exception:
+        pass
+
+    try:
+        import urllib.parse
+        async with httpx.AsyncClient(timeout=6.0) as client:
+            resp = await client.get(
+                FORWARD_GEO_URL.format(query=urllib.parse.quote(text)),
+                headers={"User-Agent": "ConnectomeAura/1.0 event-location-verify"},
+            )
+            resp.raise_for_status()
+            rows = resp.json()
+            if not rows:
+                return None
+            data = rows[0]
+            address = data.get("address") or {}
+            lat = float(data.get("lat"))
+            lon = float(data.get("lon"))
+            city = (
+                address.get("city")
+                or address.get("town")
+                or address.get("village")
+                or address.get("municipality")
+                or address.get("county")
+                or ""
+            )
+            result = {
+                "city": city,
+                "region": address.get("state") or address.get("region") or "",
+                "country": address.get("country") or "",
+                "country_code": (address.get("country_code") or "").upper(),
+                "lat": lat,
+                "lon": lon,
+            }
+            try:
+                from core.redis_client import get_redis
+                r = await get_redis()
+                await r.setex(cache_key, CACHE_TTL_SECONDS, json.dumps(result))
+            except Exception:
+                pass
+            return result
+    except Exception as e:
+        logger.debug(f"Forward geo lookup failed for {text}: {e}")
         return None
 
 

--- a/core/migrations.sql
+++ b/core/migrations.sql
@@ -763,3 +763,7 @@ CREATE INDEX IF NOT EXISTS idx_ioo_nodes_scale_depth ON ioo_nodes(node_scale, ma
 CREATE INDEX IF NOT EXISTS idx_ioo_nodes_macro_micro_score ON ioo_nodes(macro_micro_score);
 CREATE INDEX IF NOT EXISTS idx_ioo_nodes_macro_micro_grade ON ioo_nodes(macro_micro_grade);
 CREATE INDEX IF NOT EXISTS idx_ioo_nodes_primary_macro_domain ON ioo_nodes(primary_macro_domain);
+
+
+-- Event geo hardening: verified country for city/country/coordinate matching
+ALTER TABLE events ADD COLUMN IF NOT EXISTS country VARCHAR(100);

--- a/ora/agents/event_agent.py
+++ b/ora/agents/event_agent.py
@@ -156,6 +156,62 @@ def _dedup_events(events: List[Dict]) -> List[Dict]:
 
 
 
+def _city_matches(a: str, b: str) -> bool:
+    def token(value: str) -> str:
+        return re.sub(r"[^a-z0-9]+", " ", str(value or "").lower().split(",")[0]).strip()
+    aa, bb = token(a), token(b)
+    return bool(aa and bb and (aa == bb or aa in bb or bb in aa))
+
+
+async def _verify_event_geo(ev: Dict[str, Any], requested_city: str) -> Optional[Dict[str, Any]]:
+    """Require event coordinates and confirmed city/country before storing/serving.
+
+    Event cards are location-sensitive: a live event without verified lat/lng +
+    city/country can leak wrong-city cards. We either confirm/enrich from public
+    venue/address data or skip the event.
+    """
+    city = str(ev.get("city") or requested_city or "").strip()
+    country = str(ev.get("country") or "").strip()
+    lat = ev.get("latitude")
+    lng = ev.get("longitude")
+
+    needs_geo = lat in (None, "") or lng in (None, "") or not country or not _city_matches(city, requested_city)
+    if needs_geo:
+        query = ", ".join(part for part in [
+            str(ev.get("venue_name") or "").strip(),
+            str(ev.get("address") or "").strip(),
+            requested_city,
+        ] if part)
+        try:
+            from core.geo import geocode_location_query
+            geo = await geocode_location_query(query) if query else None
+        except Exception as e:
+            logger.debug("Event geo verification skipped for %s: %s", ev.get("title"), e)
+            geo = None
+        if geo:
+            lat = lat or geo.get("lat")
+            lng = lng or geo.get("lon")
+            country = country or geo.get("country") or ""
+            confirmed_city = geo.get("city") or city
+            if confirmed_city:
+                city = confirmed_city
+
+    if lat in (None, "") or lng in (None, "") or not city or not country:
+        return None
+    if requested_city and not _city_matches(city, requested_city):
+        return None
+
+    try:
+        ev["latitude"] = float(lat)
+        ev["longitude"] = float(lng)
+    except Exception:
+        return None
+    ev["city"] = city
+    ev["country"] = country
+    ev["location_verified"] = True
+    return ev
+
+
 def _city_slug(city: str) -> str:
     return re.sub(r"[^a-z0-9]+", "-", city.lower()).strip("-")
 
@@ -322,6 +378,7 @@ def _event_from_jsonld(item: Dict[str, Any], city: str, source: str, page_url: s
         "venue_name": venue,
         "address": address,
         "city": city,
+        "country": "",
         "latitude": lat,
         "longitude": lng,
         "starts_at": starts_at,
@@ -799,8 +856,16 @@ async def _upsert_events(events: List[Dict], openai_client) -> int:
                 if existing:
                     continue  # cross-source duplicate
 
-            # Generate embedding
-            embed_text = f"{ev.get('title', '')}: {ev.get('description', '')}"
+            ev = await _verify_event_geo(ev, ev.get("city", ""))
+            if not ev:
+                continue
+
+            # Generate embedding with verified city/country/coordinates so event vectors are geo-grounded.
+            embed_text = (
+                f"{ev.get('title', '')}: {ev.get('description', '')}\n"
+                f"Verified event location: {ev.get('city', '')}, {ev.get('country', '')}. "
+                f"Coordinates: {ev.get('latitude')}, {ev.get('longitude')}."
+            )
             embedding = await _generate_embedding(embed_text, openai_client)
             embed_str = f"[{','.join(str(x) for x in embedding)}]" if embedding else None
 
@@ -808,15 +873,15 @@ async def _upsert_events(events: List[Dict], openai_client) -> int:
                 """
                 INSERT INTO events (
                     external_id, title, description, category,
-                    venue_name, address, city, latitude, longitude,
+                    venue_name, address, city, country, latitude, longitude,
                     starts_at, ends_at, url, image_url,
                     price_range, source, relevance_tags, embedding,
                     updated_at
                 ) VALUES (
                     $1, $2, $3, $4,
-                    $5, $6, $7, $8, $9,
-                    $10, $11, $12, $13,
-                    $14, $15, $16, $17::vector,
+                    $5, $6, $7, $8, $9, $10,
+                    $11, $12, $13, $14,
+                    $15, $16, $17, $18::vector,
                     NOW()
                 )
                 ON CONFLICT (external_id) DO UPDATE SET
@@ -825,6 +890,10 @@ async def _upsert_events(events: List[Dict], openai_client) -> int:
                     category      = EXCLUDED.category,
                     venue_name    = EXCLUDED.venue_name,
                     address       = EXCLUDED.address,
+                    city          = EXCLUDED.city,
+                    country       = EXCLUDED.country,
+                    latitude      = EXCLUDED.latitude,
+                    longitude     = EXCLUDED.longitude,
                     starts_at     = EXCLUDED.starts_at,
                     ends_at       = EXCLUDED.ends_at,
                     url           = EXCLUDED.url,
@@ -841,6 +910,7 @@ async def _upsert_events(events: List[Dict], openai_client) -> int:
                 ev.get("venue_name", ""),
                 ev.get("address", ""),
                 ev.get("city", ""),
+                ev.get("country", ""),
                 ev.get("latitude"),
                 ev.get("longitude"),
                 ev.get("starts_at"),
@@ -863,8 +933,11 @@ async def _upsert_events(events: List[Dict], openai_client) -> int:
                     "title": ev.get("title", ""),
                     "summary": ev.get("description", ""),
                     "url": ev.get("url", ""),
-                    "location": ev.get("city", ""),
+                    "location": f"{ev.get('city', '')}, {ev.get('country', '')}".strip(', '),
                     "city": ev.get("city", ""),
+                    "country": ev.get("country", ""),
+                    "latitude": ev.get("latitude"),
+                    "longitude": ev.get("longitude"),
                     "tags": ev.get("relevance_tags", []) or [ev.get("category", "general")],
                     "relevance_score": 0.74,
                     "starts_at": ev.get("starts_at"),
@@ -1047,11 +1120,14 @@ class EventAgent:
         rows = await fetch(
             f"""
             SELECT id, external_id, title, description, category,
-                   venue_name, address, city, latitude, longitude,
+                   venue_name, address, city, country, latitude, longitude,
                    starts_at, ends_at, url, image_url, price_range,
                    source, relevance_tags
             FROM events
             WHERE city = $1
+              AND latitude IS NOT NULL
+              AND longitude IS NOT NULL
+              AND COALESCE(country, '') <> ''
               AND starts_at > NOW()
               AND starts_at < $2
               {cat_clause}
@@ -1079,7 +1155,14 @@ class EventAgent:
         from core.database import fetchrow as _fetchrow
 
         user = await _fetchrow(
-            "SELECT city, event_preferences, embedding FROM users WHERE id = $1",
+            """
+            SELECT COALESCE(NULLIF(s.location_city, ''), NULLIF(u.city, '')) AS city,
+                   NULLIF(s.location_country, '') AS country,
+                   u.event_preferences, u.embedding
+            FROM users u
+            LEFT JOIN ioo_user_state s ON s.user_id = u.id
+            WHERE u.id = $1
+            """,
             user_id,
         )
         if not user:
@@ -1089,6 +1172,7 @@ class EventAgent:
         if not city:
             return []
 
+        country = user.get("country") or ""
         prefs = user.get("event_preferences") or []
         user_embedding = user.get("embedding")  # stored as string '[...]'
         days_ahead = min(max(1, days_ahead), MAX_SERVE_WINDOW_DAYS)
@@ -1097,6 +1181,10 @@ class EventAgent:
         # Preference-based category filter
         pref_clause = ""
         params: List[Any] = [city, until]
+        country_clause = ""
+        if country:
+            params.append(country)
+            country_clause = f"AND country = ${len(params)}"
         if prefs:
             params.append(prefs)
             pref_clause = f"AND (relevance_tags && ${len(params)} OR category = ANY(${len(params)}))"
@@ -1112,11 +1200,15 @@ class EventAgent:
         rows = await fetch(
             f"""
             SELECT id, external_id, title, description, category,
-                   venue_name, address, city, latitude, longitude,
+                   venue_name, address, city, country, latitude, longitude,
                    starts_at, ends_at, url, image_url, price_range,
                    source, relevance_tags
             FROM events
             WHERE city = $1
+              AND latitude IS NOT NULL
+              AND longitude IS NOT NULL
+              AND COALESCE(country, '') <> ''
+              {country_clause}
               AND starts_at > NOW()
               AND starts_at < $2
               AND embedding IS NOT NULL
@@ -1132,11 +1224,15 @@ class EventAgent:
             rows = await fetch(
                 f"""
                 SELECT id, external_id, title, description, category,
-                       venue_name, address, city, latitude, longitude,
+                       venue_name, address, city, country, latitude, longitude,
                        starts_at, ends_at, url, image_url, price_range,
                        source, relevance_tags
                 FROM events
                 WHERE city = $1
+                  AND latitude IS NOT NULL
+                  AND longitude IS NOT NULL
+                  AND COALESCE(country, '') <> ''
+                  {country_clause}
                   AND starts_at > NOW()
                   AND starts_at < $2
                   {pref_clause}

--- a/ora/user_model.py
+++ b/ora/user_model.py
@@ -341,9 +341,54 @@ async def update_user_embedding_from_context(
                     value = ", ".join(str(v) for v in value)
                 lines.append(f"{label}: {value}")
 
-        location = profile.get("location") or profile.get("city")
-        if location:
-            lines.append(f"Location: {location}")
+        # Hard location contract: vectors should carry the user's real live
+        # location, or their explicit Travel Mode location if one is set.
+        location_city = context_answers.get("location_city") or context_answers.get("city")
+        location_country = context_answers.get("location_country") or context_answers.get("country")
+        location_lat = context_answers.get("location_lat")
+        location_lng = context_answers.get("location_lng")
+        try:
+            loc_row = await fetchrow(
+                """
+                SELECT COALESCE(NULLIF(s.location_city, ''), NULLIF(u.city, '')) AS city,
+                       NULLIF(s.location_country, '') AS country,
+                       u.location_lat, u.location_lng, u.profile
+                FROM users u
+                LEFT JOIN ioo_user_state s ON s.user_id = u.id
+                WHERE u.id = $1
+                """,
+                UUID(user_id),
+            )
+            if loc_row:
+                db_profile = loc_row.get("profile") or {}
+                if isinstance(db_profile, str):
+                    try:
+                        db_profile = json.loads(db_profile)
+                    except Exception:
+                        db_profile = {}
+                travel_enabled = bool((db_profile or profile or {}).get("travel_mode_enabled"))
+                travel_city = (db_profile or profile or {}).get("travel_city") or (db_profile or profile or {}).get("travel_location_city")
+                travel_country = (db_profile or profile or {}).get("travel_country") or (db_profile or profile or {}).get("travel_location_country")
+                if travel_enabled and travel_city:
+                    location_city = travel_city
+                    location_country = travel_country or location_country
+                    lines.append("Location source: Travel Mode")
+                else:
+                    location_city = location_city or loc_row.get("city")
+                    location_country = location_country or loc_row.get("country")
+                    location_lat = location_lat if location_lat is not None else loc_row.get("location_lat")
+                    location_lng = location_lng if location_lng is not None else loc_row.get("location_lng")
+                    if location_city:
+                        lines.append("Location source: Live/real user location")
+        except Exception as loc_e:
+            logger.debug(f"user vector location lookup skipped: {loc_e}")
+
+        if location_city or location_country:
+            lines.append(f"User location city/country: {location_city or ''}, {location_country or ''}".strip())
+        elif profile.get("location") or profile.get("city"):
+            lines.append(f"Location: {profile.get('location') or profile.get('city')}")
+        if location_lat is not None and location_lng is not None:
+            lines.append(f"User location coordinates: {location_lat}, {location_lng}")
 
         embed_text = "\n".join(lines)
 


### PR DESCRIPTION
## Summary
- require live events to have verified latitude/longitude plus city/country before storing/serving
- add event country persistence and geo verification via cached forward geocoding when source data is incomplete
- embed verified city/country/coordinates into event vectors
- refresh Now/Later user vectors with real live location or explicit Travel Mode/manual location
- include verified event city/country/coordinates in feed card metadata

## Verification
- python3 -m py_compile core/geo.py core/database.py api/routes/events.py api/routes/screens.py ora/agents/event_agent.py ora/user_model.py
- git diff --check
- light diff secret scan