### PR TITLE
Align Rest as an iVive aspect

### DIFF
--- a/api/routes/screens.py
+++ b/api/routes/screens.py
@@ -1434,7 +1434,7 @@ async def _try_real_world_card(user_id: str, tier: str, daily_limit: int, slot_i
     current_count = await get_daily_screen_count(user_id)
     rotation_bucket = datetime.now(timezone.utc).strftime("%Y-%m-%d:%H")
     digest = hashlib.sha256(f"{user_id}:{rotation_bucket}:{current_count}".encode("utf-8")).hexdigest()
-    candidates = [item for item in _CURATED_REAL_ACTIONS if not domain_filter or item.get('domain') == domain_filter or (domain_filter == 'iVive' and item.get('domain') == 'Rest')]
+    candidates = [item for item in _CURATED_REAL_ACTIONS if not domain_filter or item.get('domain') == domain_filter]
     if not candidates:
         candidates = _CURATED_REAL_ACTIONS
     candidates = _filter_temporal_branch(candidates, feed_mode)
@@ -1448,9 +1448,6 @@ async def _try_real_world_card(user_id: str, tier: str, daily_limit: int, slot_i
     start = int(digest[:8], 16) % len(candidates)
     idx = (start + slot_index + current_count) % len(candidates)
     item = dict(candidates[idx])
-    if domain_filter == 'iVive' and item.get('domain') == 'Rest':
-        item['domain'] = 'iVive'
-        item['tag'] = item.get('tag') or 'recovery'
     return await _build_screen_response_from_spec(user_id, tier, daily_limit, _real_action_spec(item, feed_mode=feed_mode))
 
 
@@ -1506,11 +1503,12 @@ _STATIC_FALLBACK_CARDS = [
     {
         "title": "Choose Rest on purpose",
         "image": "https://images.unsplash.com/photo-1495195134817-aeb325a55b65?w=1200&auto=format&fit=crop",
-        "body": "A deliberate recovery micro-step: put your phone down for three minutes and let your nervous system learn that nothing needs to be chased right now.",
-        "domain": "Rest",
+        "body": "An iVive recovery micro-step: put your phone down for three minutes and let your nervous system learn that nothing needs to be chased right now.",
+        "domain": "iVive",
+        "aspect": "Rest",
         "tag": "recovery",
         "button": "Begin rest →",
-        "why": "Rest is the substrate under iVive, Eviva, and Aventi. Sometimes the best next action is reducing load before adding direction.",
+        "why": "Rest is an iVive aspect — the recovery layer that makes Eviva contribution and Aventi aliveness sustainable. Sometimes the best next action is reducing load before adding direction.",
         "steps": [
             "Put the phone face down or away from your hand.",
             "Let your eyes rest on one still object.",
@@ -1542,7 +1540,7 @@ async def _static_fallback_card(
         "layout": "card_stack",
         "components": [
             {"type": "hero_image", "source": item["image"], "alt": item["title"]},
-            {"type": "category_badge", "text": item["domain"].upper(), "color": "#00d4aa"},
+            {"type": "category_badge", "text": (f'{item["domain"]} · {item["aspect"]}' if item.get("aspect") else item["domain"]).upper(), "color": "#00d4aa"},
             {"type": "headline", "text": item["title"]},
             {"type": "body", "text": item["body"]},
             _path_progression_component(kind="fallback_action", domain=item["domain"], current_stage="confirm_micro_node"),
@@ -1564,9 +1562,10 @@ async def _static_fallback_card(
             "metadata": {
             "agent": "StaticFallbackAgent",
             "source": "static_fallback",
-            "domain": "iVive" if item["domain"] == "Rest" else item["domain"],
+            "domain": item["domain"],
+            "aspect": item.get("aspect"),
             "path_progression": _path_progression_metadata(kind="fallback_action", domain=item["domain"], current_stage="confirm_micro_node"),
-            "tags": [item["tag"], "mvp_stability"],
+            "tags": [item["tag"], "mvp_stability", *([str(item["aspect"]).lower()] if item.get("aspect") else [])],
             "fallback_reason": reason,
             "ioo_execution_status": "pending_user_response",
             "ioo_learning_event": "fallback_card_shown",

--- a/ora/agents/ioo_enrichment_agent.py
+++ b/ora/agents/ioo_enrichment_agent.py
@@ -25,6 +25,9 @@ class IOOEnrichmentAgent:
     CATEGORIES_BY_DOMAIN = {
         "iVive": [
             "iVive physical mental spiritual creative financial self-growth",
+            "iVive rest recovery sleep nervous system restoration",
+            "iVive rest Sabbath digital detox low-stimulation renewal",
+            "iVive rest active recovery after burnout or overwork",
             "health/fitness",
             "mental wellness",
             "finance",
@@ -43,11 +46,6 @@ class IOOEnrichmentAgent:
             "Aventi fun adventure events dating travel friendship",
             "Aventi local micro-adventures and friendship opportunities",
             "Aventi creative dates, social hobbies, and travel readiness",
-        ],
-        "Rest": [
-            "Rest recovery sleep nervous system restoration",
-            "Rest Sabbath digital detox low-stimulation renewal",
-            "Rest active recovery after burnout or overwork",
         ],
     }
     CATEGORIES = [category for categories in CATEGORIES_BY_DOMAIN.values() for category in categories]
@@ -72,16 +70,23 @@ class IOOEnrichmentAgent:
         self.openai = openai_client
 
     def pick_categories(self, count: int = 4) -> List[str]:
-        """Pick a daily balanced slice across Ora's lived-action domains.
+        """Pick a daily balanced slice across the three lived-action domains.
 
-        Feed quality drops when enrichment over-rotates into one silo. The
-        daily cycle should always touch iVive, Eviva, Aventi, and Rest so Ora
-        can build bridges between capability, service, adventure, and recovery.
+        Rest is an iVive aspect, not a fourth domain. The daily cycle still
+        keeps recovery alive by pairing one iVive rest/recovery category with
+        iVive capacity, Eviva contribution, and Aventi aliveness.
         """
         seed = int(hashlib.sha256(str(date.today()).encode()).hexdigest(), 16)
-        picked: List[str] = []
-        for offset, (_domain, categories) in enumerate(self.CATEGORIES_BY_DOMAIN.items()):
-            picked.append(categories[(seed + offset) % len(categories)])
+        ivive_categories = self.CATEGORIES_BY_DOMAIN["iVive"]
+        rest_categories = [c for c in ivive_categories if "rest" in c.lower() or "sleep" in c.lower() or "recovery" in c.lower()]
+        capacity_categories = [c for c in ivive_categories if c not in rest_categories]
+        picked: List[str] = [
+            capacity_categories[seed % len(capacity_categories)],
+            self.CATEGORIES_BY_DOMAIN["Eviva"][(seed + 1) % len(self.CATEGORIES_BY_DOMAIN["Eviva"])],
+            self.CATEGORIES_BY_DOMAIN["Aventi"][(seed + 2) % len(self.CATEGORIES_BY_DOMAIN["Aventi"])],
+        ]
+        if count > len(picked) and rest_categories:
+            picked.append(rest_categories[(seed + 3) % len(rest_categories)])
         if count <= len(picked):
             return picked[:count]
         remaining = [category for category in self.CATEGORIES if category not in picked]
@@ -153,17 +158,17 @@ class IOOEnrichmentAgent:
                 ("Try one social hobby taster session", "Book or attend one beginner-friendly class, meetup, or creative group where conversation happens naturally.", "physical", ["Aventi", "social", "hobby"]),
                 ("Create a simple travel-readiness checklist", "List passport, budget, dates, destination constraints, and one first booking/research action.", "digital", ["Aventi", "travel", "readiness"]),
             ],
-            "Rest recovery sleep nervous system restoration": [
-                ("Choose tonight's shutdown time and protect it", "Set a specific lights-out target, remove one sleep blocker, and start winding down 45 minutes before bed.", "physical", ["Rest", "sleep", "recovery"]),
-                ("Do a 10-minute nervous-system reset", "Use breath, stretching, yoga nidra, or a slow walk to shift out of stress before choosing the next action.", "physical", ["Rest", "nervous-system", "reset"]),
+            "iVive rest recovery sleep nervous system restoration": [
+                ("Choose tonight's shutdown time and protect it", "Set a specific lights-out target, remove one sleep blocker, and start winding down 45 minutes before bed.", "physical", ["iVive", "rest", "sleep", "recovery"]),
+                ("Do a 10-minute nervous-system reset", "Use breath, stretching, yoga nidra, or a slow walk to shift out of stress before choosing the next action.", "physical", ["iVive", "rest", "nervous-system", "reset"]),
             ],
-            "Rest Sabbath digital detox low-stimulation renewal": [
-                ("Schedule a two-hour low-stimulation block", "Pick a calendar window with no feeds, messages, or productivity pressure; choose one restorative activity.", "hybrid", ["Rest", "digital-detox", "renewal"]),
-                ("Prepare a phone-free recovery menu", "Write three offline options—walk, bath, reading, prayer, music, cooking—so rest has an easy next step.", "digital", ["Rest", "offline", "renewal"]),
+            "iVive rest Sabbath digital detox low-stimulation renewal": [
+                ("Schedule a two-hour low-stimulation block", "Pick a calendar window with no feeds, messages, or productivity pressure; choose one restorative activity.", "hybrid", ["iVive", "rest", "digital-detox", "renewal"]),
+                ("Prepare a phone-free recovery menu", "Write three offline options—walk, bath, reading, prayer, music, cooking—so rest has an easy next step.", "digital", ["iVive", "rest", "offline", "renewal"]),
             ],
-            "Rest active recovery after burnout or overwork": [
-                ("Replace one hard task with active recovery", "Choose one non-urgent task to defer and do a gentle body-based recovery action instead.", "physical", ["Rest", "burnout", "active-recovery"]),
-                ("Name the next minimum viable obligation", "Reduce today's pressure to the one obligation that actually matters, then leave space for recovery.", "digital", ["Rest", "prioritisation", "burnout"]),
+            "iVive rest active recovery after burnout or overwork": [
+                ("Replace one hard task with active recovery", "Choose one non-urgent task to defer and do a gentle body-based recovery action instead.", "physical", ["iVive", "rest", "burnout", "active-recovery"]),
+                ("Name the next minimum viable obligation", "Reduce today's pressure to the one obligation that actually matters, then leave space for recovery.", "digital", ["iVive", "rest", "prioritisation", "burnout"]),
             ],
             "finance": [
                 ("List all recurring monthly expenses", "Create visibility before making any financial changes.", "digital", ["finance", "budget"]),
@@ -188,7 +193,7 @@ class IOOEnrichmentAgent:
             prompt = f"""
 Extract actionable IOO graph nodes for the goal category: {category}.
 Use the search evidence below. Return JSON only: {{"steps": [{{"title": str, "description": str, "step_type": "digital|physical|hybrid", "tags": [str], "confidence": 0-1, "source_url": str}}]}}
-Prefer clear opportunities, prerequisites, habits, metrics, physical actions, and digital actions. For Eviva categories, extract concrete jobs, volunteering roles, open-source contribution paths, community initiatives, impact startups, and prerequisites that may need iVive capability-building. For Aventi, prefer specific lived experiences, social invitations, local adventures, dating/friendship pathways, and travel-readiness bridges. For Rest, prefer recovery, sleep, nervous-system, Sabbath/digital-detox, and burnout-repair nodes that make action sustainable. Avoid vague motivation, generic content, and broad labels like "exercise more" unless the title itself contains a concrete next action.
+Prefer clear opportunities, prerequisites, habits, metrics, physical actions, and digital actions. For Eviva categories, extract concrete jobs, volunteering roles, open-source contribution paths, community initiatives, impact startups, and prerequisites that may need iVive capability-building. For Aventi, prefer specific lived experiences, social invitations, local adventures, dating/friendship pathways, and travel-readiness bridges. For iVive rest categories, prefer recovery, sleep, nervous-system, Sabbath/digital-detox, and burnout-repair nodes that make action sustainable; keep their domain as iVive and mark rest/recovery in tags. Avoid vague motivation, generic content, and broad labels like "exercise more" unless the title itself contains a concrete next action.
 
 Evidence:
 {source_text}
@@ -240,7 +245,9 @@ Evidence:
         return str(node["id"]) if node else None
 
     async def run_daily(self, categories: Optional[List[str]] = None) -> Dict[str, Any]:
-        categories = categories or self.pick_categories(3)
+        # Daily enrichment should touch all three lived-action domains, with
+        # rest/recovery treated as a continuously tested iVive aspect.
+        categories = categories or self.pick_categories(4)
         proposed = promoted = skipped = 0
         for category in categories:
             results: List[Dict[str, str]] = []
@@ -287,8 +294,8 @@ Evidence:
             return "Eviva"
         if category.startswith("Aventi") or "adventure" in lowered or "dating" in lowered or "travel" in lowered:
             return "Aventi"
-        if category.startswith("Rest") or "sleep" in lowered or "recovery" in lowered or "burnout" in lowered:
-            return "Rest"
+        if "rest" in lowered or "sleep" in lowered or "recovery" in lowered or "burnout" in lowered:
+            return "iVive"
         return "iVive"
 
 


### PR DESCRIPTION
## Summary
- Removes Rest as a fourth IOO enrichment domain and folds rest/recovery categories under iVive.
- Keeps daily enrichment balanced across iVive, Eviva, Aventi, plus a continuously-tested iVive rest/recovery aspect.
- Updates fallback Rest card metadata to domain=iVive with aspect=Rest and rest tags.

## Verification
- git diff --check
- python3 -m compileall api/routes/screens.py ora/agents/ioo_enrichment_agent.py
- python3 scripts/guard_no_public_secrets.py

Note: local python3 is 3.9, so direct import of broader backend graph code is blocked by existing Python 3.10+ type syntax outside this diff.