### PR TITLE
Allow deeper feed screen batches

### DIFF
--- a/api/routes/screens.py
+++ b/api/routes/screens.py
@@ -1905,11 +1905,11 @@ async def get_screen_batch(
     user_id: str = Depends(get_current_user_id),
 ):
     """
-    Fetch up to 5 screens at once for TikTok-style prefetching.
+    Fetch a queue of screens for TikTok-style prefetching.
     Each screen goes through the same logic as /next.
     Returns a list of ScreenResponse objects.
     """
-    count = max(1, min(body.count, 5))  # cap at 5
+    count = max(1, min(body.count, 20))  # keep a deep ready queue without unbounded generation
 
     # Check subscription tier once
     user_row = await fetchrow(


### PR DESCRIPTION
## Summary
- raise the API screen batch queue cap from 5 to 20
- document the endpoint as a feed queue/prefetch primitive instead of a tiny batch
- keeps a cap so generation remains bounded

## Validation
- python3 -m compileall -q api/routes/screens.py
- git diff --check
- python3 scripts/guard_no_public_secrets.py

Do not merge until Avi approves.
