### PR TITLE
Stop false feed limit screens

### DIFF
--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -8,8 +8,10 @@ import os
 from typing import Any, Dict, List
 
 from fastapi import APIRouter, HTTPException, Header
+from pydantic import BaseModel
 
-from core.database import fetchrow, fetch
+from core.database import execute, fetchrow, fetch
+from core.config import settings
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/admin", tags=["admin"])
@@ -20,6 +22,61 @@ ADMIN_TOKEN = os.getenv("ADMIN_TOKEN") or os.getenv("ADMIN_SECRET", "")
 def _require_admin(x_admin_token: str = Header(default="")):
     if not ADMIN_TOKEN or x_admin_token != ADMIN_TOKEN:
         raise HTTPException(status_code=403, detail="Forbidden")
+
+
+class AdminTierResetRequest(BaseModel):
+    email: str = "carlosandromeda8@gmail.com"
+    tier: str = "sovereign"
+    reset_feed: bool = True
+
+
+@router.post("/users/tier-reset")
+async def admin_set_user_tier_and_reset_feed(
+    body: AdminTierResetRequest,
+    x_admin_token: str = Header(default=""),
+) -> Dict[str, Any]:
+    """Admin-only tier switcher plus feed counter reset for testing tiers."""
+    _require_admin(x_admin_token)
+    email = body.email.strip().lower()
+    if email not in settings.admin_email_list:
+        raise HTTPException(status_code=403, detail="Tier switcher is restricted to admin accounts")
+    tier = body.tier.strip().lower()
+    if tier not in {"free", "explorer", "sovereign", "premium"}:
+        raise HTTPException(status_code=400, detail="Invalid tier")
+
+    user = await fetchrow("SELECT id, email FROM users WHERE lower(email) = $1", email)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    user_id = str(user["id"])
+    normalized_tier = "explorer" if tier == "premium" else tier
+
+    await execute(
+        "UPDATE users SET subscription_tier = $2, is_premium = $3 WHERE id = $1",
+        user_id,
+        normalized_tier,
+        normalized_tier in ("explorer", "sovereign"),
+    )
+    await execute(
+        """
+        INSERT INTO subscriptions (user_id, tier, status, updated_at)
+        VALUES ($1, $2, 'active', NOW())
+        ON CONFLICT (user_id)
+        DO UPDATE SET tier = EXCLUDED.tier, status = 'active', updated_at = NOW()
+        """,
+        user_id,
+        normalized_tier,
+    )
+
+    feed_reset = False
+    if body.reset_feed:
+        try:
+            from core.redis_client import redis_delete
+            await redis_delete(f"screens_today:{user_id}")
+            feed_reset = True
+        except Exception as err:
+            logger.warning("Admin tier switch feed reset failed for %s: %s", email, err)
+
+    return {"ok": True, "email": email, "tier": normalized_tier, "feed_reset": feed_reset}
 
 
 @router.get("/insights")

--- a/api/routes/screens.py
+++ b/api/routes/screens.py
@@ -1156,7 +1156,7 @@ async def _build_screen_response_from_spec(user_id: str, tier: str, daily_limit:
         screen_spec_db_id=db_id,
         screens_today=screens_today,
         daily_limit=daily_limit,
-        is_limited=(tier == "free"),
+        is_limited=False,
     )
 
 
@@ -1728,7 +1728,7 @@ async def _try_ioo_card(
             screen_spec_db_id=db_id,
             screens_today=screens_today,
             daily_limit=daily_limit,
-            is_limited=(tier == "free"),
+            is_limited=False,
         )
     except Exception as _err:
         logger.warning(f"IOO card build failed, falling back to brain: {_err}")
@@ -1751,23 +1751,24 @@ async def get_next_screen(
 ):
     """
     Request the next screen from Ora.
-    MVP/stability: preserves auth but does not hard-block the main feed on
-    daily limits. Paywall enforcement can return after feed stability is proven.
+    Request the next screen from Aura.
+    Enforces the PricingAgent daily screen limit before generating, so free
+    users keep a real daily cap without false limiter cards in the queue.
     """
     # Check subscription tier via PricingAgent-backed tier guard
-    from api.tier_guard import check_tier_limit, get_user_tier, build_upgrade_card, get_current_usage
+    from api.tier_guard import get_user_tier, build_upgrade_card
     from ora.agents.pricing_agent import get_pricing_agent
 
     tier = await get_user_tier(user_id)
     pricing_agent = get_pricing_agent()
     limits = await pricing_agent.get_tier_limits(tier)
     configured_daily_limit = limits.get("daily_screens", 10)
-    daily_limit = configured_daily_limit if configured_daily_limit == -1 else max(configured_daily_limit, 999)
+    daily_limit = configured_daily_limit
 
     # Get current count BEFORE incrementing (brain will increment)
     current_count = await get_daily_screen_count(user_id)
 
-    if False and daily_limit != -1 and current_count >= daily_limit:
+    if daily_limit != -1 and current_count >= daily_limit:
         # Return Ora's warm upgrade card instead of a cold 402
         upgrade_card = await build_upgrade_card("daily_screens", daily_limit, tier)
         raise HTTPException(
@@ -1881,7 +1882,7 @@ async def get_next_screen(
         screen_spec_db_id=db_id,
         screens_today=screens_today,
         daily_limit=daily_limit,
-        is_limited=(tier == "free"),
+        is_limited=False,
     )
 
 
@@ -1918,22 +1919,30 @@ async def get_screen_batch(
     if not user_row:
         raise HTTPException(status_code=404, detail="User not found")
 
-    tier = user_row["subscription_tier"]
-    is_free = tier == "free"
-    daily_limit = max(settings.FREE_TIER_DAILY_SCREENS, 999)
+    from api.tier_guard import get_user_tier, build_upgrade_card
+    from ora.agents.pricing_agent import get_pricing_agent
 
-    if is_free:
-        # MVP/stability: keep authentication, but do not hard-block the primary
-        # feed on daily limits. A broken empty feed is worse than over-serving
-        # during pre-product-stability.
-        current_count = await get_daily_screen_count(user_id)
-        if current_count >= settings.FREE_TIER_DAILY_SCREENS:
-            logger.info(
-                "Free user %s exceeded configured daily screen limit (%s/%s); serving feed for MVP stability",
-                user_id[:8],
-                current_count,
-                settings.FREE_TIER_DAILY_SCREENS,
-            )
+    tier = await get_user_tier(user_id)
+    pricing_agent = get_pricing_agent()
+    limits = await pricing_agent.get_tier_limits(tier)
+    daily_limit = limits.get("daily_screens", settings.FREE_TIER_DAILY_SCREENS)
+    current_count = await get_daily_screen_count(user_id)
+    if daily_limit != -1 and current_count >= daily_limit:
+        upgrade_card = await build_upgrade_card("daily_screens", daily_limit, tier)
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail={
+                "error": "daily_limit_reached",
+                "screens_today": current_count,
+                "daily_limit": daily_limit,
+                "tier": tier,
+                "upgrade_card": upgrade_card,
+                "upgrade_url": "/api/payments/checkout",
+            },
+            headers={"X-Upgrade-URL": "/api/payments/checkout"},
+        )
+    if daily_limit != -1:
+        count = min(count, max(0, daily_limit - current_count))
 
     brain = get_brain()
     results: List[ScreenResponse] = []
@@ -2033,7 +2042,7 @@ async def get_screen_batch(
                     screen_spec_db_id=db_id,
                     screens_today=screens_today,
                     daily_limit=daily_limit,
-                    is_limited=is_free,
+                    is_limited=False,
                 )
             )
         except HTTPException:

--- a/api/tier_guard.py
+++ b/api/tier_guard.py
@@ -47,7 +47,7 @@ async def get_user_tier(user_id: str) -> str:
         from core.config import settings
         from core.database import fetchrow as _fetchrow
         from uuid import UUID as _UUID
-        _row = await _fetchrow("SELECT email FROM users WHERE id = $1", _str(user_id))
+        _row = await _fetchrow("SELECT email FROM users WHERE id = $1", str(user_id))
         if _row and (_row["email"] or "").lower() in settings.admin_email_list:
             return "sovereign"
     except Exception:

--- a/core/config.py
+++ b/core/config.py
@@ -102,7 +102,7 @@ class Settings(BaseSettings):
 
 
     # Monetization — Legacy
-    FREE_TIER_DAILY_SCREENS: int = 10
+    FREE_TIER_DAILY_SCREENS: int = 20
     PREMIUM_PRICE_CENTS: int = 1299
 
     # Stripe — set these in Railway env vars after creating products at dashboard.stripe.com

--- a/ora/agents/pricing_agent.py
+++ b/ora/agents/pricing_agent.py
@@ -33,13 +33,13 @@ ORA_TIERS: Dict[str, Any] = {
         "description": "Start your path with Aura",
         "features": [
             "4 active paths on your IOO graph",
-            "10 daily discovery cards",
+            "20 daily discovery cards",
             "Basic Aura chat",
             "Community feed",
             "Earn CP through contributions",
         ],
         "limits": {
-            "daily_screens": 10,
+            "daily_screens": 20,
             "active_paths": 4,
             "chat_messages_daily": 10,
             "drive_docs_indexed": 0,


### PR DESCRIPTION
## Summary
- fixes the false feed limiter by only marking the feed limited when the real PricingAgent daily limit is reached
- sets the Free tier baseline to 20 daily discovery/path cards
- enforces the real daily screen limit before generation; batch requests return remaining cards and then 402 on the next request once the cap is reached
- preserves Explorer/Sovereign unlimited daily feed behaviour
- fixes admin email sovereign bypass in the tier guard
- adds an admin-only tier switch/reset endpoint for `carlosandromeda8@gmail.com`

## Validation
- python3 -m compileall -q api/routes/screens.py api/routes/admin.py api/tier_guard.py ora/agents/pricing_agent.py core/config.py
- git diff --check
- python3 scripts/guard_no_public_secrets.py

Do not merge until Avi approves.
