### PR TITLE
Expose CP totals on user profile

### DIFF
--- a/api/routes/users.py
+++ b/api/routes/users.py
@@ -143,6 +143,8 @@ async def get_profile(user_id: str = Depends(get_current_user_id)):
         profile=profile_data,
         created_at=row["created_at"],
         last_active=row["last_active"],
+        cp_balance=_cp_balance,
+        total_dao_cp=_total_cp,
     )
 
 

--- a/core/models.py
+++ b/core/models.py
@@ -45,6 +45,8 @@ class UserProfile(BaseModel):
     profile: Dict[str, Any]
     created_at: datetime
     last_active: Optional[datetime]
+    cp_balance: int = 0
+    total_dao_cp: int = 0
     domain: Optional[DomainType] = None  # active domain focus
 
 


### PR DESCRIPTION
## Summary\n- adds cp_balance and total_dao_cp to the UserProfile response model\n- returns the same canonical cp_transactions-derived totals at top-level and nested profile metadata\n- keeps CP displays aligned across Profile, DAO, and contribution surfaces\n\n## Validation\n- python3 -m compileall -q core/models.py api/routes/users.py\n- git diff --check\n- python3 scripts/guard_no_public_secrets.py\n\nDo not merge until Avi approves.