### PR TITLE
fix(dao): register dao_public router so /api/public/dao/* endpoints work

### DIFF
--- a/main.py
+++ b/main.py
@@ -39,6 +39,7 @@ from api.routes import journal as journal_routes
 from api.routes import feature_lab as feature_lab_routes
 from api.routes import mood as mood_routes
 from api.routes import dao as dao_routes
+from api.routes import dao_public as dao_public_routes
 try:
     from api.routes.dao_rewards import router as dao_rewards_router
 except Exception:
@@ -299,6 +300,7 @@ app.include_router(journal_routes.router)
 app.include_router(feature_lab_routes.router)
 app.include_router(mood_routes.router)
 app.include_router(dao_routes.router)
+app.include_router(dao_public_routes.router)
 if dao_rewards_router:
     app.include_router(dao_rewards_router)
 app.include_router(world_routes.router)


### PR DESCRIPTION
## What

The `dao_public` router (defined in `api/routes/dao_public.py`) was never mounted in `main.py`, so every endpoint it declares returns 404:

- `/api/public/dao/pulse`
- `/api/public/dao/aura-thought` (canonical) + `/api/public/dao/ora-thought` (legacy alias)
- `/api/public/dao/leaderboard`

The `atdao.org` homepage's "Aura is currently thinking" card has been failing silently and falling back to its static placeholder. Mounting the router restores the live feed.

## Why surfaced now

Discovered while verifying the Wave 4 rename PR — every `/api/public/dao/*` endpoint returned 404 even after the new code shipped. Investigation showed the router was never registered. Pre-existing bug, surfaced by the rename audit. Fixing now.

## Test

- `python3 -m py_compile main.py` exits 0
- After deploy, `curl https://connectome-api-production.up.railway.app/api/public/dao/pulse` should return JSON instead of 404.
