### PR TITLE
Add action-boundary evidence schema

### DIFF
--- a/core/action_boundary.py
+++ b/core/action_boundary.py
@@ -1,0 +1,259 @@
+"""Action-boundary evidence for approval-gated Aura actions.
+
+This module is intentionally storage-agnostic. It gives approval-gated workers a
+canonical evidence envelope they can persist, compare, and audit before any
+sensitive external write executes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import secrets
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class ActionType(str, Enum):
+    READ = "read"
+    DRAFT = "draft"
+    SEND = "send"
+    SCHEDULE = "schedule"
+    PURCHASE = "purchase"
+    DELETE = "delete"
+    EXTERNAL_API_WRITE = "external_api_write"
+
+
+class DataClassification(str, Enum):
+    PUBLIC = "public"
+    INTERNAL = "internal"
+    PRIVATE = "private"
+    SENSITIVE = "sensitive"
+    SECRETS = "secrets"
+    FINANCIAL = "financial"
+    HEALTH = "health"
+
+
+_SECRETISH_KEYS = {
+    "api_key",
+    "apikey",
+    "authorization",
+    "cookie",
+    "password",
+    "secret",
+    "token",
+}
+
+
+class ActionBoundaryError(ValueError):
+    """Raised when approval evidence no longer permits execution."""
+
+
+class FinalActionResult(BaseModel):
+    success: bool
+    external_id: Optional[str] = None
+    message: Optional[str] = None
+    rollback_notes: Optional[str] = None
+    recorded_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class ApprovalBinding(BaseModel):
+    """Exact approval grant bound to one canonical action boundary."""
+
+    tool: str
+    args_hash: str
+    target_resource: str
+    action_type: ActionType
+    resource_scope: str
+    data_classification: DataClassification
+    policy_version: str
+    approver_ref: str
+    expires_at: datetime
+    evidence_hash: str
+
+    @field_validator("args_hash", "evidence_hash")
+    @classmethod
+    def _validate_sha256(cls, value: str) -> str:
+        if len(value) != 64 or any(c not in "0123456789abcdef" for c in value):
+            raise ValueError("expected lowercase sha256 hex digest")
+        return value
+
+    def is_expired(self, now: Optional[datetime] = None) -> bool:
+        return (now or datetime.now(timezone.utc)) >= self.expires_at
+
+
+class WorkerResumeToken(BaseModel):
+    """Short-lived async worker capability bound to the approval evidence hash."""
+
+    token_id: str = Field(default_factory=lambda: secrets.token_urlsafe(24))
+    evidence_hash: str
+    expires_at: datetime
+    used_at: Optional[datetime] = None
+
+    def consume(self, expected_evidence_hash: str, now: Optional[datetime] = None) -> None:
+        now = now or datetime.now(timezone.utc)
+        if self.used_at is not None:
+            raise ActionBoundaryError("worker resume token has already been used")
+        if now >= self.expires_at:
+            raise ActionBoundaryError("worker resume token has expired")
+        if not hmac.compare_digest(self.evidence_hash, expected_evidence_hash):
+            raise ActionBoundaryError("worker resume token does not match action evidence")
+        self.used_at = now
+
+
+class ActionBoundaryEvidence(BaseModel):
+    """Evidence envelope explaining exactly what an approved action may do."""
+
+    user_intent: str
+    action_type: ActionType
+    target_resource: str
+    resource_scope: str
+    data_classification: DataClassification
+    policy_version: str
+    tool: str
+    tool_args: Dict[str, Any] = Field(default_factory=dict)
+    approval_binding: Optional[ApprovalBinding] = None
+    worker_resume_token: Optional[WorkerResumeToken] = None
+    final_result: Optional[FinalActionResult] = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+    @field_validator("user_intent", "target_resource", "resource_scope", "policy_version", "tool")
+    @classmethod
+    def _non_empty(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("must not be empty")
+        return value.strip()
+
+    @property
+    def args_hash(self) -> str:
+        return _sha256(_canonical_json(self.tool_args))
+
+    @property
+    def evidence_hash(self) -> str:
+        return _sha256(_canonical_json(self._boundary_payload()))
+
+    def _boundary_payload(self) -> Dict[str, Any]:
+        """Fields that must not drift after approval."""
+
+        return {
+            "user_intent": self.user_intent,
+            "action_type": self.action_type.value,
+            "target_resource": self.target_resource,
+            "resource_scope": self.resource_scope,
+            "data_classification": self.data_classification.value,
+            "policy_version": self.policy_version,
+            "tool": self.tool,
+            "args_hash": self.args_hash,
+        }
+
+    def bind_approval(
+        self,
+        *,
+        approver_ref: str,
+        expires_at: datetime,
+        resume_ttl: Optional[timedelta] = None,
+    ) -> "ActionBoundaryEvidence":
+        """Attach an approval binding and optional short-lived worker token."""
+
+        binding = ApprovalBinding(
+            tool=self.tool,
+            args_hash=self.args_hash,
+            target_resource=self.target_resource,
+            action_type=self.action_type,
+            resource_scope=self.resource_scope,
+            data_classification=self.data_classification,
+            policy_version=self.policy_version,
+            approver_ref=approver_ref,
+            expires_at=expires_at,
+            evidence_hash=self.evidence_hash,
+        )
+        token = None
+        if resume_ttl is not None:
+            token = WorkerResumeToken(
+                evidence_hash=self.evidence_hash,
+                expires_at=min(expires_at, datetime.now(timezone.utc) + resume_ttl),
+            )
+        return self.model_copy(update={"approval_binding": binding, "worker_resume_token": token})
+
+    def assert_execution_allowed(self, now: Optional[datetime] = None) -> None:
+        """Reject execution unless the current boundary exactly matches approval."""
+
+        if self.approval_binding is None:
+            raise ActionBoundaryError("missing approval binding")
+        binding = self.approval_binding
+        if binding.is_expired(now):
+            raise ActionBoundaryError("approval binding has expired")
+        checks = {
+            "tool": self.tool,
+            "args_hash": self.args_hash,
+            "target_resource": self.target_resource,
+            "action_type": self.action_type,
+            "resource_scope": self.resource_scope,
+            "data_classification": self.data_classification,
+            "policy_version": self.policy_version,
+            "evidence_hash": self.evidence_hash,
+        }
+        for field, current in checks.items():
+            approved = getattr(binding, field)
+            if isinstance(current, Enum):
+                current = current.value
+            if isinstance(approved, Enum):
+                approved = approved.value
+            if not hmac.compare_digest(str(current), str(approved)):
+                raise ActionBoundaryError(f"approval drift detected for {field}")
+
+    def record_result(self, result: FinalActionResult) -> "ActionBoundaryEvidence":
+        """Return a copy with immutable final-result evidence attached."""
+
+        return self.model_copy(update={"final_result": result})
+
+    def to_audit_log(self) -> Dict[str, Any]:
+        """Safe audit payload: enough to explain, without storing raw secrets."""
+
+        return {
+            **self._boundary_payload(),
+            "created_at": self.created_at.isoformat(),
+            "approval_expires_at": self.approval_binding.expires_at.isoformat()
+            if self.approval_binding
+            else None,
+            "approver_ref": self.approval_binding.approver_ref if self.approval_binding else None,
+            "tool_args_redacted": _redact(self.tool_args),
+            "worker_resume_token": {
+                "token_id_hash": _sha256(self.worker_resume_token.token_id)
+                if self.worker_resume_token
+                else None,
+                "expires_at": self.worker_resume_token.expires_at.isoformat()
+                if self.worker_resume_token
+                else None,
+                "used": self.worker_resume_token.used_at is not None
+                if self.worker_resume_token
+                else None,
+            },
+            "final_result": self.final_result.model_dump(mode="json") if self.final_result else None,
+        }
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _sha256(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _redact(value: Any) -> Any:
+    if isinstance(value, dict):
+        redacted: Dict[str, Any] = {}
+        for key, item in value.items():
+            if key.lower() in _SECRETISH_KEYS:
+                redacted[key] = "[REDACTED]"
+            else:
+                redacted[key] = _redact(item)
+        return redacted
+    if isinstance(value, list):
+        return [_redact(item) for item in value]
+    return value

--- a/tests/test_action_boundary.py
+++ b/tests/test_action_boundary.py
@@ -1,0 +1,95 @@
+from datetime import datetime, timedelta, timezone
+import unittest
+
+from core.action_boundary import (
+    ActionBoundaryError,
+    ActionBoundaryEvidence,
+    ActionType,
+    DataClassification,
+    FinalActionResult,
+)
+
+
+class ActionBoundaryEvidenceTests(unittest.TestCase):
+    def _evidence(self):
+        return ActionBoundaryEvidence(
+            user_intent="Send Avi the weekly Aura growth summary",
+            action_type=ActionType.SEND,
+            target_resource="telegram:user:avi",
+            resource_scope="single message to Avi only",
+            data_classification=DataClassification.PRIVATE,
+            policy_version="approval-policy-v1",
+            tool="message.send",
+            tool_args={
+                "target": "telegram:user:avi",
+                "message": "summary",
+                "metadata": {"token": "do-not-log"},
+            },
+        )
+
+    def test_allows_execution_when_boundary_matches_approval(self):
+        evidence = self._evidence().bind_approval(
+            approver_ref="user-hash:avi",
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+            resume_ttl=timedelta(minutes=2),
+        )
+
+        evidence.assert_execution_allowed()
+        evidence.worker_resume_token.consume(evidence.evidence_hash)
+
+        self.assertIsNotNone(evidence.worker_resume_token.used_at)
+
+    def test_rejects_approval_drift_when_args_change(self):
+        evidence = self._evidence().bind_approval(
+            approver_ref="user-hash:avi",
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+        )
+        drifted = evidence.model_copy(
+            update={"tool_args": {**evidence.tool_args, "message": "changed after approval"}}
+        )
+
+        with self.assertRaisesRegex(ActionBoundaryError, "approval drift"):
+            drifted.assert_execution_allowed()
+
+    def test_rejects_expired_worker_resume_token(self):
+        evidence = self._evidence().bind_approval(
+            approver_ref="user-hash:avi",
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+            resume_ttl=timedelta(minutes=2),
+        )
+
+        with self.assertRaisesRegex(ActionBoundaryError, "expired"):
+            evidence.worker_resume_token.consume(
+                evidence.evidence_hash,
+                now=datetime.now(timezone.utc) + timedelta(minutes=3),
+            )
+
+    def test_rejects_reused_worker_resume_token(self):
+        evidence = self._evidence().bind_approval(
+            approver_ref="user-hash:avi",
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+            resume_ttl=timedelta(minutes=2),
+        )
+
+        evidence.worker_resume_token.consume(evidence.evidence_hash)
+        with self.assertRaisesRegex(ActionBoundaryError, "already been used"):
+            evidence.worker_resume_token.consume(evidence.evidence_hash)
+
+    def test_records_final_result_and_redacts_secrets_from_audit_log(self):
+        evidence = self._evidence().bind_approval(
+            approver_ref="user-hash:avi",
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+            resume_ttl=timedelta(minutes=2),
+        )
+        completed = evidence.record_result(
+            FinalActionResult(success=True, external_id="msg_123", rollback_notes="delete msg_123")
+        )
+        audit = completed.to_audit_log()
+
+        self.assertEqual(audit["final_result"]["external_id"], "msg_123")
+        self.assertEqual(audit["tool_args_redacted"]["metadata"]["token"], "[REDACTED]")
+        self.assertNotIn("do-not-log", str(audit))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds storage-agnostic action-boundary evidence models for approval-gated Aura actions
- Binds approvals to tool, args hash, target resource, scope, data classification, policy version, and evidence hash
- Adds short-lived single-use worker resume token checks plus safe audit-log redaction and final-result recording

Closes #79 as a first schema/test slice; follow-up wiring can attach this to real approval-gated tools.

## Verification
- python3 -m compileall -q core/action_boundary.py tests/test_action_boundary.py
- python3 -m unittest tests/test_action_boundary.py
- python3 scripts/guard_no_public_secrets.py