### PR TITLE
Harden action-boundary audit redaction

### DIFF
--- a/core/action_boundary.py
+++ b/core/action_boundary.py
@@ -48,6 +48,17 @@ _SECRETISH_KEYS = {
     "token",
 }
 
+_SECRETISH_KEY_PARTS = {
+    "authorization",
+    "cookie",
+    "credential",
+    "key",
+    "password",
+    "secret",
+    "session",
+    "token",
+}
+
 
 class ActionBoundaryError(ValueError):
     """Raised when approval evidence no longer permits execution."""
@@ -249,7 +260,7 @@ def _redact(value: Any) -> Any:
     if isinstance(value, dict):
         redacted: Dict[str, Any] = {}
         for key, item in value.items():
-            if key.lower() in _SECRETISH_KEYS:
+            if _is_secretish_key(key):
                 redacted[key] = "[REDACTED]"
             else:
                 redacted[key] = _redact(item)
@@ -257,3 +268,28 @@ def _redact(value: Any) -> Any:
     if isinstance(value, list):
         return [_redact(item) for item in value]
     return value
+
+
+def _is_secretish_key(key: str) -> bool:
+    """Detect common secret-bearing key names before audit logging.
+
+    Approval evidence may include provider-native argument dictionaries. Those
+    APIs often use camelCase, kebab-case, or nested names like access_token,
+    refreshToken, set-cookie, and clientSecret. Treating only exact key matches
+    as sensitive can leak credentials into otherwise safe audit logs.
+    """
+
+    normalized_chars = []
+    previous = ""
+    for char in key:
+        if char.isupper() and previous and (previous.islower() or previous.isdigit()):
+            normalized_chars.append(" ")
+        normalized_chars.append(char.lower() if char.isalnum() else " ")
+        previous = char
+    normalized = "".join(normalized_chars)
+    compact = normalized.replace(" ", "")
+    if compact in _SECRETISH_KEYS:
+        return True
+
+    parts = set(normalized.split())
+    return bool(parts.intersection(_SECRETISH_KEY_PARTS))

--- a/tests/test_action_boundary.py
+++ b/tests/test_action_boundary.py
@@ -23,7 +23,15 @@ class ActionBoundaryEvidenceTests(unittest.TestCase):
             tool_args={
                 "target": "telegram:user:avi",
                 "message": "summary",
-                "metadata": {"token": "do-not-log"},
+                "metadata": {
+                    "token": "do-not-log",
+                    "access_token": "oauth-access-token",
+                    "refreshToken": "oauth-refresh-token",
+                    "clientSecret": "oauth-client-secret",
+                    "headers": {"set-cookie": "session-cookie"},
+                    "api_version": "2026-05-11",
+                    "monkey": "banana",
+                },
             },
         )
 
@@ -88,7 +96,19 @@ class ActionBoundaryEvidenceTests(unittest.TestCase):
 
         self.assertEqual(audit["final_result"]["external_id"], "msg_123")
         self.assertEqual(audit["tool_args_redacted"]["metadata"]["token"], "[REDACTED]")
+        self.assertEqual(audit["tool_args_redacted"]["metadata"]["access_token"], "[REDACTED]")
+        self.assertEqual(audit["tool_args_redacted"]["metadata"]["refreshToken"], "[REDACTED]")
+        self.assertEqual(audit["tool_args_redacted"]["metadata"]["clientSecret"], "[REDACTED]")
+        self.assertEqual(
+            audit["tool_args_redacted"]["metadata"]["headers"]["set-cookie"], "[REDACTED]"
+        )
+        self.assertEqual(audit["tool_args_redacted"]["metadata"]["api_version"], "2026-05-11")
+        self.assertEqual(audit["tool_args_redacted"]["metadata"]["monkey"], "banana")
         self.assertNotIn("do-not-log", str(audit))
+        self.assertNotIn("oauth-access-token", str(audit))
+        self.assertNotIn("oauth-refresh-token", str(audit))
+        self.assertNotIn("oauth-client-secret", str(audit))
+        self.assertNotIn("session-cookie", str(audit))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- broaden action-boundary audit redaction to provider-native secret key names such as access_token, refreshToken, clientSecret, and set-cookie
- keep benign similarly-shaped fields like api_version and monkey unredacted so audit logs stay useful
- extend action-boundary tests to prevent secret values from appearing in audit payloads

## Verification
- python3 -m unittest tests/test_action_boundary.py
- python3 scripts/guard_no_public_secrets.py
- git diff --check