### PR TITLE
Fix screenshot feedback settings access

### DIFF
--- a/api/routes/feedback.py
+++ b/api/routes/feedback.py
@@ -16,6 +16,7 @@ from core.models import FeedbackSubmit, FeedbackResponse
 from api.middleware import get_current_user_id
 from aura.brain import get_brain
 from core.database import execute, fetchrow
+from core.config import settings
 from openai import AsyncOpenAI
 
 from core.feedback_storage import ScreenshotStorageError, delete_feedback_screenshot, store_feedback_screenshot


### PR DESCRIPTION
## Summary\n- import shared runtime settings in the feedback API route so screenshot AI analysis and ephemeral deletion can read their feature flags/config\n- restores the global feedback screenshot loop instead of raising NameError when a screenshot is submitted\n\n## Verification\n- python3 -m py_compile api/routes/feedback.py\n- python3 -m unittest tests.test_action_boundary -v\n- python3 scripts/guard_no_public_secrets.py