### PR TITLE
Add policy context to action-boundary evidence

### DIFF
--- a/core/action_boundary.py
+++ b/core/action_boundary.py
@@ -38,6 +38,14 @@ class DataClassification(str, Enum):
     HEALTH = "health"
 
 
+class ApprovalMode(str, Enum):
+    """How an action boundary was authorized to execute."""
+
+    USER_APPROVAL = "user_approval"
+    POLICY_PREAPPROVED = "policy_preapproved"
+    HUMAN_OPERATOR = "human_operator"
+
+
 _SECRETISH_KEYS = {
     "api_key",
     "apikey",
@@ -82,6 +90,8 @@ class ApprovalBinding(BaseModel):
     resource_scope: str
     data_classification: DataClassification
     policy_version: str
+    policy_rule_id: str
+    approval_mode: ApprovalMode
     approver_ref: str
     expires_at: datetime
     evidence_hash: str
@@ -125,6 +135,10 @@ class ActionBoundaryEvidence(BaseModel):
     resource_scope: str
     data_classification: DataClassification
     policy_version: str
+    policy_rule_id: str = "unspecified"
+    approval_mode: ApprovalMode = ApprovalMode.USER_APPROVAL
+    cost_or_risk: Optional[str] = None
+    rollback_notes: Optional[str] = None
     tool: str
     tool_args: Dict[str, Any] = Field(default_factory=dict)
     approval_binding: Optional[ApprovalBinding] = None
@@ -132,7 +146,14 @@ class ActionBoundaryEvidence(BaseModel):
     final_result: Optional[FinalActionResult] = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
-    @field_validator("user_intent", "target_resource", "resource_scope", "policy_version", "tool")
+    @field_validator(
+        "user_intent",
+        "target_resource",
+        "resource_scope",
+        "policy_version",
+        "policy_rule_id",
+        "tool",
+    )
     @classmethod
     def _non_empty(cls, value: str) -> str:
         if not value.strip():
@@ -157,6 +178,8 @@ class ActionBoundaryEvidence(BaseModel):
             "resource_scope": self.resource_scope,
             "data_classification": self.data_classification.value,
             "policy_version": self.policy_version,
+            "policy_rule_id": self.policy_rule_id,
+            "approval_mode": self.approval_mode.value,
             "tool": self.tool,
             "args_hash": self.args_hash,
         }
@@ -178,6 +201,8 @@ class ActionBoundaryEvidence(BaseModel):
             resource_scope=self.resource_scope,
             data_classification=self.data_classification,
             policy_version=self.policy_version,
+            policy_rule_id=self.policy_rule_id,
+            approval_mode=self.approval_mode,
             approver_ref=approver_ref,
             expires_at=expires_at,
             evidence_hash=self.evidence_hash,
@@ -206,6 +231,8 @@ class ActionBoundaryEvidence(BaseModel):
             "resource_scope": self.resource_scope,
             "data_classification": self.data_classification,
             "policy_version": self.policy_version,
+            "policy_rule_id": self.policy_rule_id,
+            "approval_mode": self.approval_mode,
             "evidence_hash": self.evidence_hash,
         }
         for field, current in checks.items():
@@ -232,6 +259,8 @@ class ActionBoundaryEvidence(BaseModel):
             if self.approval_binding
             else None,
             "approver_ref": self.approval_binding.approver_ref if self.approval_binding else None,
+            "cost_or_risk": self.cost_or_risk,
+            "rollback_notes": self.rollback_notes,
             "tool_args_redacted": _redact(self.tool_args),
             "worker_resume_token": {
                 "token_id_hash": _sha256(self.worker_resume_token.token_id)

--- a/tests/test_action_boundary.py
+++ b/tests/test_action_boundary.py
@@ -5,6 +5,7 @@ from core.action_boundary import (
     ActionBoundaryError,
     ActionBoundaryEvidence,
     ActionType,
+    ApprovalMode,
     DataClassification,
     FinalActionResult,
 )
@@ -19,6 +20,10 @@ class ActionBoundaryEvidenceTests(unittest.TestCase):
             resource_scope="single message to Avi only",
             data_classification=DataClassification.PRIVATE,
             policy_version="approval-policy-v1",
+            policy_rule_id="send.private-message.requires-approval",
+            approval_mode=ApprovalMode.USER_APPROVAL,
+            cost_or_risk="Private message is sent externally to one Telegram recipient.",
+            rollback_notes="Delete the Telegram message if supported by the provider.",
             tool="message.send",
             tool_args={
                 "target": "telegram:user:avi",
@@ -59,6 +64,16 @@ class ActionBoundaryEvidenceTests(unittest.TestCase):
         with self.assertRaisesRegex(ActionBoundaryError, "approval drift"):
             drifted.assert_execution_allowed()
 
+    def test_rejects_approval_drift_when_policy_context_changes(self):
+        evidence = self._evidence().bind_approval(
+            approver_ref="user-hash:avi",
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+        )
+        drifted = evidence.model_copy(update={"policy_rule_id": "different-rule"})
+
+        with self.assertRaisesRegex(ActionBoundaryError, "approval drift"):
+            drifted.assert_execution_allowed()
+
     def test_rejects_expired_worker_resume_token(self):
         evidence = self._evidence().bind_approval(
             approver_ref="user-hash:avi",
@@ -95,6 +110,16 @@ class ActionBoundaryEvidenceTests(unittest.TestCase):
         audit = completed.to_audit_log()
 
         self.assertEqual(audit["final_result"]["external_id"], "msg_123")
+        self.assertEqual(audit["policy_rule_id"], "send.private-message.requires-approval")
+        self.assertEqual(audit["approval_mode"], "user_approval")
+        self.assertEqual(
+            audit["cost_or_risk"],
+            "Private message is sent externally to one Telegram recipient.",
+        )
+        self.assertEqual(
+            audit["rollback_notes"],
+            "Delete the Telegram message if supported by the provider.",
+        )
         self.assertEqual(audit["tool_args_redacted"]["metadata"]["token"], "[REDACTED]")
         self.assertEqual(audit["tool_args_redacted"]["metadata"]["access_token"], "[REDACTED]")
         self.assertEqual(audit["tool_args_redacted"]["metadata"]["refreshToken"], "[REDACTED]")


### PR DESCRIPTION
## Summary
- Add explicit `ApprovalMode` plus `policy_rule_id` to action-boundary evidence and approval bindings.
- Include policy context in the immutable boundary payload so rule/mode drift forces a fresh approval before execution.
- Add safe audit context fields for cost/risk and rollback notes without storing raw tool secrets.

## Why
This seeds part of the autonomous admin intelligence direction from #55: sensitive life-admin actions need exact, auditable approval context, including the policy rule and approval mode that authorized execution.

## Verification
- `python3 -m unittest discover -s tests`
- `python3 scripts/guard_no_public_secrets.py`
