### PR TITLE
fix: redact embedded audit log secrets

### DIFF
--- a/core/action_boundary.py
+++ b/core/action_boundary.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import re
 import secrets
 from datetime import datetime, timedelta, timezone
 from enum import Enum
@@ -66,6 +67,11 @@ _SECRETISH_KEY_PARTS = {
     "session",
     "token",
 }
+
+_BEARER_SECRET_RE = re.compile(r"(?i)\b(bearer|basic)\s+[a-z0-9._~+/=-]{12,}")
+_URL_SECRET_PARAM_RE = re.compile(
+    r"(?i)([?&](?:access[_-]?token|api[_-]?key|auth[_-]?token|client[_-]?secret|code|key|password|refresh[_-]?token|secret|session|token)=)([^&#\s]+)"
+)
 
 
 class ActionBoundaryError(ValueError):
@@ -296,7 +302,16 @@ def _redact(value: Any) -> Any:
         return redacted
     if isinstance(value, list):
         return [_redact(item) for item in value]
+    if isinstance(value, str):
+        return _redact_secretish_string(value)
     return value
+
+
+def _redact_secretish_string(value: str) -> str:
+    """Redact credentials embedded in otherwise non-secret audit fields."""
+
+    redacted = _BEARER_SECRET_RE.sub(lambda match: f"{match.group(1)} [REDACTED]", value)
+    return _URL_SECRET_PARAM_RE.sub(lambda match: f"{match.group(1)}[REDACTED]", redacted)
 
 
 def _is_secretish_key(key: str) -> bool:

--- a/tests/test_action_boundary.py
+++ b/tests/test_action_boundary.py
@@ -34,6 +34,8 @@ class ActionBoundaryEvidenceTests(unittest.TestCase):
                     "refreshToken": "oauth-refresh-token",
                     "clientSecret": "oauth-client-secret",
                     "headers": {"set-cookie": "session-cookie"},
+                    "callback_url": "https://example.org/callback?code=oauth-code&state=safe-state",
+                    "request_note": "Authorization: Bearer sk-live-do-not-log-value",
                     "api_version": "2026-05-11",
                     "monkey": "banana",
                 },
@@ -127,6 +129,14 @@ class ActionBoundaryEvidenceTests(unittest.TestCase):
         self.assertEqual(
             audit["tool_args_redacted"]["metadata"]["headers"]["set-cookie"], "[REDACTED]"
         )
+        self.assertEqual(
+            audit["tool_args_redacted"]["metadata"]["callback_url"],
+            "https://example.org/callback?code=[REDACTED]&state=safe-state",
+        )
+        self.assertEqual(
+            audit["tool_args_redacted"]["metadata"]["request_note"],
+            "Authorization: Bearer [REDACTED]",
+        )
         self.assertEqual(audit["tool_args_redacted"]["metadata"]["api_version"], "2026-05-11")
         self.assertEqual(audit["tool_args_redacted"]["metadata"]["monkey"], "banana")
         self.assertNotIn("do-not-log", str(audit))
@@ -134,6 +144,8 @@ class ActionBoundaryEvidenceTests(unittest.TestCase):
         self.assertNotIn("oauth-refresh-token", str(audit))
         self.assertNotIn("oauth-client-secret", str(audit))
         self.assertNotIn("session-cookie", str(audit))
+        self.assertNotIn("oauth-code", str(audit))
+        self.assertNotIn("sk-live-do-not-log-value", str(audit))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Redacts bearer/basic credentials embedded in string audit fields
- Redacts sensitive URL query parameters before action-boundary audit logs are persisted
- Expands action-boundary tests for embedded OAuth/code and authorization-note leakage

## Verification
- PYTHONPATH=. uv run --with pytest pytest tests/test_action_boundary.py
- python3 scripts/guard_no_public_secrets.py

Supports #55 by hardening autonomous admin/action audit trails before more approval-gated workers are added.