### PR TITLE
fix: centralize frontend callback URL config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ CONNECTOME_REPO_DIR=/app
 CONNECTOME_RUNTIME_DIR=/tmp/connectome
 CORS_ORIGINS=["https://atdao.org","https://www.atdao.org","https://avielcarlos.github.io"]
 FRONTEND_BASE_URL=https://avielcarlos.github.io/connectome-web
+# Optional: only set when OAuth callback routes diverge from FRONTEND_BASE_URL defaults.
+GOOGLE_FRONTEND_CALLBACK_URL=
+GITHUB_FRONTEND_CALLBACK_URL=
 
 # Database (Railway auto-sets this when you add a PostgreSQL plugin)
 DATABASE_URL=postgresql://user:pass@host:5432/connectome

--- a/api/routes/github_oauth.py
+++ b/api/routes/github_oauth.py
@@ -18,9 +18,6 @@ router = APIRouter(prefix="/api/auth/github", tags=["github-auth"])
 GITHUB_AUTH_URL = "https://github.com/login/oauth/authorize"
 GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token"
 GITHUB_USER_URL = "https://api.github.com/user"
-FRONTEND_CALLBACK_URL = "https://avielcarlos.github.io/connectome-web/auth/github-callback"
-
-
 async def _ensure_schema() -> None:
     await execute("ALTER TABLE users ADD COLUMN IF NOT EXISTS github_username TEXT")
     await execute("ALTER TABLE users ADD COLUMN IF NOT EXISTS github_avatar_url TEXT")
@@ -65,7 +62,7 @@ async def github_callback(code: str = Query(...), state: str = Query(...)):
     """Exchange GitHub code, store profile fields, and redirect to frontend."""
     user_id = decode_token(state)
     if not user_id:
-        return RedirectResponse(f"{FRONTEND_CALLBACK_URL}?github_connected=false&error=invalid_state")
+        return RedirectResponse(f"{settings.github_frontend_callback_url}?github_connected=false&error=invalid_state")
 
     await _ensure_schema()
     async with httpx.AsyncClient(timeout=15) as client:
@@ -81,11 +78,11 @@ async def github_callback(code: str = Query(...), state: str = Query(...)):
         )
     if token_resp.status_code != 200:
         logger.error("GitHub token exchange failed: %s %s", token_resp.status_code, token_resp.text)
-        return RedirectResponse(f"{FRONTEND_CALLBACK_URL}?github_connected=false&error=token_exchange")
+        return RedirectResponse(f"{settings.github_frontend_callback_url}?github_connected=false&error=token_exchange")
 
     access_token = token_resp.json().get("access_token")
     if not access_token:
-        return RedirectResponse(f"{FRONTEND_CALLBACK_URL}?github_connected=false&error=no_token")
+        return RedirectResponse(f"{settings.github_frontend_callback_url}?github_connected=false&error=no_token")
 
     async with httpx.AsyncClient(timeout=10) as client:
         user_resp = await client.get(
@@ -94,13 +91,13 @@ async def github_callback(code: str = Query(...), state: str = Query(...)):
         )
     if user_resp.status_code != 200:
         logger.error("GitHub profile fetch failed: %s %s", user_resp.status_code, user_resp.text)
-        return RedirectResponse(f"{FRONTEND_CALLBACK_URL}?github_connected=false&error=profile_fetch")
+        return RedirectResponse(f"{settings.github_frontend_callback_url}?github_connected=false&error=profile_fetch")
 
     gh = user_resp.json()
     username = (gh.get("login") or "").lower().strip()
     avatar_url = gh.get("avatar_url")
     if not username:
-        return RedirectResponse(f"{FRONTEND_CALLBACK_URL}?github_connected=false&error=no_username")
+        return RedirectResponse(f"{settings.github_frontend_callback_url}?github_connected=false&error=no_username")
 
     uid = UUID(user_id)
     await execute(
@@ -133,5 +130,5 @@ async def github_callback(code: str = Query(...), state: str = Query(...)):
     )
 
     return RedirectResponse(
-        f"{FRONTEND_CALLBACK_URL}?github_connected=true&github_username={urllib.parse.quote(username)}"
+        f"{settings.github_frontend_callback_url}?github_connected=true&github_username={urllib.parse.quote(username)}"
     )

--- a/api/routes/google_auth.py
+++ b/api/routes/google_auth.py
@@ -62,9 +62,7 @@ DRIVE_SCOPES = [
     "https://www.googleapis.com/auth/drive.readonly",
 ]
 
-# Where the web app lives — after OAuth we redirect here with the JWT
-FRONTEND_CALLBACK_URL = "https://avielcarlos.github.io/connectome-web/auth/callback"
-
+# Where the web app lives — after OAuth we redirect to settings.google_frontend_callback_url.
 
 # ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -317,7 +315,7 @@ async def google_callback(
     """
     if error:
         # User denied consent — redirect to login page with error
-        frontend_error = f"{FRONTEND_CALLBACK_URL}?error={urllib.parse.quote(error)}"
+        frontend_error = f"{settings.google_frontend_callback_url}?error={urllib.parse.quote(error)}"
         return RedirectResponse(frontend_error)
 
     drive_requested = ":drive" in state
@@ -327,7 +325,7 @@ async def google_callback(
         token_data = await _exchange_code(code)
     except HTTPException as e:
         return RedirectResponse(
-            f"{FRONTEND_CALLBACK_URL}?error={urllib.parse.quote(e.detail)}"
+            f"{settings.google_frontend_callback_url}?error={urllib.parse.quote(e.detail)}"
         )
 
     access_token = token_data.get("access_token")
@@ -341,7 +339,7 @@ async def google_callback(
         user_info = await _get_user_info(access_token)
     except HTTPException as e:
         return RedirectResponse(
-            f"{FRONTEND_CALLBACK_URL}?error={urllib.parse.quote(e.detail)}"
+            f"{settings.google_frontend_callback_url}?error={urllib.parse.quote(e.detail)}"
         )
 
     google_id = user_info.get("sub")
@@ -414,7 +412,7 @@ async def google_callback(
     )
 
     # Redirect to frontend with JWT
-    redirect_url = f"{FRONTEND_CALLBACK_URL}?token={urllib.parse.quote(jwt_token)}"
+    redirect_url = f"{settings.google_frontend_callback_url}?token={urllib.parse.quote(jwt_token)}"
     return RedirectResponse(redirect_url)
 
 

--- a/api/routes/services.py
+++ b/api/routes/services.py
@@ -30,7 +30,6 @@ router = APIRouter(prefix="/api/services", tags=["services"])
 
 STRIPE_SECRET_KEY = os.getenv("STRIPE_SECRET_KEY", "")
 STRIPE_WEBHOOK_SECRET = os.getenv("STRIPE_WEBHOOK_SECRET", "")
-FRONTEND_BASE_URL = os.getenv("FRONTEND_BASE_URL", "https://avielcarlos.github.io/connectome-web").rstrip("/")
 
 # ---------------------------------------------------------------------------
 # Service catalog
@@ -255,7 +254,7 @@ async def create_service_order(
 
     # Redirect customers back to the web app, not the API origin.
     # FRONTEND_BASE_URL should be set in Railway if the production frontend moves.
-    origin = FRONTEND_BASE_URL
+    origin = settings.frontend_url()
 
     try:
         import httpx

--- a/core/config.py
+++ b/core/config.py
@@ -61,6 +61,9 @@ class Settings(BaseSettings):
     # App
     APP_ENV: str = "development"
     LOG_LEVEL: str = "INFO"
+    FRONTEND_BASE_URL: str = "https://avielcarlos.github.io/connectome-web"
+    GOOGLE_FRONTEND_CALLBACK_URL: str = ""
+    GITHUB_FRONTEND_CALLBACK_URL: str = ""
     CORS_ORIGINS: List[str] = [
         "http://localhost:3000",
         "http://localhost:8081",
@@ -134,6 +137,20 @@ class Settings(BaseSettings):
     def has_stripe(self) -> bool:
         return bool(self.STRIPE_SECRET_KEY)
 
+    def frontend_url(self, path: str = "") -> str:
+        """Build a frontend URL from the configured base without double slashes."""
+        base = (self.FRONTEND_BASE_URL or "").rstrip("/")
+        suffix = path if path.startswith("/") else f"/{path}" if path else ""
+        return f"{base}{suffix}"
+
+    @property
+    def google_frontend_callback_url(self) -> str:
+        return (self.GOOGLE_FRONTEND_CALLBACK_URL or self.frontend_url("/auth/callback")).rstrip("?")
+
+    @property
+    def github_frontend_callback_url(self) -> str:
+        return (self.GITHUB_FRONTEND_CALLBACK_URL or self.frontend_url("/auth/github-callback")).rstrip("?")
+
     @field_validator("CORS_ORIGINS", mode="before")
     @classmethod
     def parse_cors(cls, v):
@@ -194,6 +211,8 @@ class Settings(BaseSettings):
             errors.append("REDIS_URL must not point at localhost in production")
         if any(origin == "*" for origin in self.CORS_ORIGINS):
             errors.append("CORS_ORIGINS must not contain '*' in production")
+        if not self.FRONTEND_BASE_URL or "localhost" in self.FRONTEND_BASE_URL or "127.0.0.1" in self.FRONTEND_BASE_URL:
+            errors.append("FRONTEND_BASE_URL must be a non-localhost URL in production")
         admin_secret = self.ADMIN_TOKEN or self.ADMIN_SECRET
         if not admin_secret or admin_secret == "connectome-admin-secret" or len(admin_secret) < 32:
             errors.append("ADMIN_TOKEN or ADMIN_SECRET must be configured with a non-default value of at least 32 characters")

--- a/tests/test_frontend_urls.py
+++ b/tests/test_frontend_urls.py
@@ -1,0 +1,27 @@
+from core.config import Settings
+
+
+def test_frontend_url_joins_paths_without_double_slashes():
+    settings = Settings(FRONTEND_BASE_URL="https://example.com/connectome/")
+
+    assert settings.frontend_url() == "https://example.com/connectome"
+    assert settings.frontend_url("/auth/callback") == "https://example.com/connectome/auth/callback"
+    assert settings.frontend_url("upgrade/success") == "https://example.com/connectome/upgrade/success"
+
+
+def test_oauth_frontend_callbacks_default_from_base_url():
+    settings = Settings(FRONTEND_BASE_URL="https://app.example")
+
+    assert settings.google_frontend_callback_url == "https://app.example/auth/callback"
+    assert settings.github_frontend_callback_url == "https://app.example/auth/github-callback"
+
+
+def test_oauth_frontend_callbacks_can_be_overridden_independently():
+    settings = Settings(
+        FRONTEND_BASE_URL="https://app.example",
+        GOOGLE_FRONTEND_CALLBACK_URL="https://auth.example/google-done",
+        GITHUB_FRONTEND_CALLBACK_URL="https://auth.example/github-done",
+    )
+
+    assert settings.google_frontend_callback_url == "https://auth.example/google-done"
+    assert settings.github_frontend_callback_url == "https://auth.example/github-done"


### PR DESCRIPTION
## Summary
Centralizes the frontend URL settings used by OAuth callbacks and service checkout redirects so Connectome can move frontend hosts without code changes.

## Changes
- Added `FRONTEND_BASE_URL`, `GOOGLE_FRONTEND_CALLBACK_URL`, and `GITHUB_FRONTEND_CALLBACK_URL` settings helpers.
- Switched Google/GitHub OAuth callback redirects and service checkout redirect origins to the shared settings.
- Documented optional callback override env vars and added URL helper tests.

## Testing
- `python3 -m py_compile core/config.py api/routes/github_oauth.py api/routes/google_auth.py api/routes/services.py tests/test_frontend_urls.py`
- Inline `Settings` assertions for frontend callback URL generation
- `python3 scripts/guard_no_public_secrets.py`

Refs AvielCarlos/connectome-backend#40