### PR TITLE
Make OAuth callback URLs API-base driven

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@
 # App / runtime
 APP_ENV=production
 LOG_LEVEL=INFO
+API_BASE_URL=https://connectome-api-production.up.railway.app
 CONNECTOME_API_BASE=https://connectome-api-production.up.railway.app
 CONNECTOME_REPO_DIR=/app
 CONNECTOME_RUNTIME_DIR=/tmp/connectome
@@ -50,13 +51,15 @@ WORKER_TELEGRAM_CHANNEL_ID=-1003968154861
 GITHUB_TOKEN=
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
-GITHUB_REDIRECT_URI=https://connectome-api-production.up.railway.app/api/auth/github/callback
+# Optional: defaults to API_BASE_URL + /api/auth/github/callback.
+GITHUB_REDIRECT_URI=
 GITHUB_WEBHOOK_SECRET=
 
 # Google OAuth / Drive / Places
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
-GOOGLE_REDIRECT_URI=https://connectome-api-production.up.railway.app/api/auth/google/callback
+# Optional: defaults to API_BASE_URL + /api/auth/google/callback.
+GOOGLE_REDIRECT_URI=
 GOOGLE_PLACES_API_KEY=
 
 # AI providers

--- a/api/routes/github_oauth.py
+++ b/api/routes/github_oauth.py
@@ -49,7 +49,7 @@ async def github_login(token: str = Query(..., description="Current Connectome J
     await _ensure_schema()
     params = {
         "client_id": _require_client_id(),
-        "redirect_uri": settings.GITHUB_REDIRECT_URI,
+        "redirect_uri": settings.github_redirect_uri,
         "scope": "user:email read:user",
         "state": token,
         "allow_signup": "true",
@@ -72,7 +72,7 @@ async def github_callback(code: str = Query(...), state: str = Query(...)):
                 "client_id": _require_client_id(),
                 "client_secret": _require_client_secret(),
                 "code": code,
-                "redirect_uri": settings.GITHUB_REDIRECT_URI,
+                "redirect_uri": settings.github_redirect_uri,
             },
             headers={"Accept": "application/json"},
         )

--- a/api/routes/google_auth.py
+++ b/api/routes/google_auth.py
@@ -12,16 +12,16 @@ Endpoints:
 Environment variables required:
   GOOGLE_CLIENT_ID      — from console.cloud.google.com
   GOOGLE_CLIENT_SECRET  — from console.cloud.google.com
-  GOOGLE_REDIRECT_URI   — must match OAuth app config:
-                          https://connectome-api-production.up.railway.app/api/auth/google/callback
+  API_BASE_URL          — public backend base URL; callback defaults to
+                          API_BASE_URL + /api/auth/google/callback
+  GOOGLE_REDIRECT_URI   — optional override when OAuth callback routes diverge
 
 Setup instructions:
   1. Go to console.cloud.google.com → APIs & Services → Credentials
   2. Create OAuth 2.0 Client ID (Web application)
-  3. Add authorized redirect URI:
-       https://connectome-api-production.up.railway.app/api/auth/google/callback
-  4. Set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET in Railway env vars
-  5. Also add GOOGLE_REDIRECT_URI if different from default above
+  3. Add the authorized redirect URI matching API_BASE_URL + /api/auth/google/callback
+  4. Set API_BASE_URL, GOOGLE_CLIENT_ID, and GOOGLE_CLIENT_SECRET in runtime env vars
+  5. Also add GOOGLE_REDIRECT_URI if different from that default
 """
 
 import hashlib
@@ -87,9 +87,7 @@ def _get_google_client_secret() -> str:
 
 
 def _get_redirect_uri() -> str:
-    return settings.GOOGLE_REDIRECT_URI or (
-        "https://connectome-api-production.up.railway.app/api/auth/google/callback"
-    )
+    return settings.google_redirect_uri
 
 
 def _build_auth_url(scopes: list[str], state: str, *, force_consent: bool = True) -> str:

--- a/core/config.py
+++ b/core/config.py
@@ -40,7 +40,8 @@ class Settings(BaseSettings):
     GITHUB_TOKEN: str = ""
     GITHUB_CLIENT_ID: str = ""
     GITHUB_CLIENT_SECRET: str = ""
-    GITHUB_REDIRECT_URI: str = "https://connectome-api-production.up.railway.app/api/auth/github/callback"
+    # Optional override. Defaults to API_BASE_URL + /api/auth/github/callback.
+    GITHUB_REDIRECT_URI: str = ""
 
     # Aura brain backup freshness
     ORA_BACKUP_SCHEDULER_ENABLED: bool = True
@@ -61,6 +62,7 @@ class Settings(BaseSettings):
     # App
     APP_ENV: str = "development"
     LOG_LEVEL: str = "INFO"
+    API_BASE_URL: str = "https://connectome-api-production.up.railway.app"
     FRONTEND_BASE_URL: str = "https://avielcarlos.github.io/connectome-web"
     GOOGLE_FRONTEND_CALLBACK_URL: str = ""
     GITHUB_FRONTEND_CALLBACK_URL: str = ""
@@ -96,10 +98,10 @@ class Settings(BaseSettings):
 
     # Google OAuth (for Sign In with Google + Drive integration)
     # Setup: console.cloud.google.com → APIs & Services → Credentials → OAuth 2.0 Client ID
-    # Authorized redirect URI: https://connectome-api-production.up.railway.app/api/auth/google/callback
+    # Authorized redirect URI: API_BASE_URL + /api/auth/google/callback unless GOOGLE_REDIRECT_URI overrides it.
     GOOGLE_CLIENT_ID: str = ""
     GOOGLE_CLIENT_SECRET: str = ""
-    GOOGLE_REDIRECT_URI: str = "https://connectome-api-production.up.railway.app/api/auth/google/callback"
+    GOOGLE_REDIRECT_URI: str = ""
     FACEBOOK_APP_ID: str = ""
     APPLE_CLIENT_ID: str = ""
     IOS_BUNDLE_ID: str = ""
@@ -137,11 +139,26 @@ class Settings(BaseSettings):
     def has_stripe(self) -> bool:
         return bool(self.STRIPE_SECRET_KEY)
 
-    def frontend_url(self, path: str = "") -> str:
-        """Build a frontend URL from the configured base without double slashes."""
-        base = (self.FRONTEND_BASE_URL or "").rstrip("/")
+    def _join_base_url(self, base_url: str, path: str = "") -> str:
+        base = (base_url or "").rstrip("/")
         suffix = path if path.startswith("/") else f"/{path}" if path else ""
         return f"{base}{suffix}"
+
+    def api_url(self, path: str = "") -> str:
+        """Build a backend/public API URL from the configured base without double slashes."""
+        return self._join_base_url(self.API_BASE_URL, path)
+
+    def frontend_url(self, path: str = "") -> str:
+        """Build a frontend URL from the configured base without double slashes."""
+        return self._join_base_url(self.FRONTEND_BASE_URL, path)
+
+    @property
+    def github_redirect_uri(self) -> str:
+        return (self.GITHUB_REDIRECT_URI or self.api_url("/api/auth/github/callback")).rstrip("?")
+
+    @property
+    def google_redirect_uri(self) -> str:
+        return (self.GOOGLE_REDIRECT_URI or self.api_url("/api/auth/google/callback")).rstrip("?")
 
     @property
     def google_frontend_callback_url(self) -> str:
@@ -211,6 +228,8 @@ class Settings(BaseSettings):
             errors.append("REDIS_URL must not point at localhost in production")
         if any(origin == "*" for origin in self.CORS_ORIGINS):
             errors.append("CORS_ORIGINS must not contain '*' in production")
+        if not self.API_BASE_URL or "localhost" in self.API_BASE_URL or "127.0.0.1" in self.API_BASE_URL:
+            errors.append("API_BASE_URL must be a non-localhost URL in production")
         if not self.FRONTEND_BASE_URL or "localhost" in self.FRONTEND_BASE_URL or "127.0.0.1" in self.FRONTEND_BASE_URL:
             errors.append("FRONTEND_BASE_URL must be a non-localhost URL in production")
         admin_secret = self.ADMIN_TOKEN or self.ADMIN_SECRET

--- a/tests/test_frontend_urls.py
+++ b/tests/test_frontend_urls.py
@@ -9,6 +9,14 @@ def test_frontend_url_joins_paths_without_double_slashes():
     assert settings.frontend_url("upgrade/success") == "https://example.com/connectome/upgrade/success"
 
 
+def test_api_url_joins_paths_without_double_slashes():
+    settings = Settings(API_BASE_URL="https://api.example.com/")
+
+    assert settings.api_url() == "https://api.example.com"
+    assert settings.api_url("/health") == "https://api.example.com/health"
+    assert settings.api_url("api/screens/next") == "https://api.example.com/api/screens/next"
+
+
 def test_oauth_frontend_callbacks_default_from_base_url():
     settings = Settings(FRONTEND_BASE_URL="https://app.example")
 
@@ -25,3 +33,21 @@ def test_oauth_frontend_callbacks_can_be_overridden_independently():
 
     assert settings.google_frontend_callback_url == "https://auth.example/google-done"
     assert settings.github_frontend_callback_url == "https://auth.example/github-done"
+
+
+def test_backend_oauth_callbacks_default_from_api_base_url():
+    settings = Settings(API_BASE_URL="https://api.example")
+
+    assert settings.google_redirect_uri == "https://api.example/api/auth/google/callback"
+    assert settings.github_redirect_uri == "https://api.example/api/auth/github/callback"
+
+
+def test_backend_oauth_callbacks_can_be_overridden_independently():
+    settings = Settings(
+        API_BASE_URL="https://api.example",
+        GOOGLE_REDIRECT_URI="https://auth.example/google/callback",
+        GITHUB_REDIRECT_URI="https://auth.example/github/callback",
+    )
+
+    assert settings.google_redirect_uri == "https://auth.example/google/callback"
+    assert settings.github_redirect_uri == "https://auth.example/github/callback"


### PR DESCRIPTION
## Summary
- Add API_BASE_URL-backed URL builder for public backend links
- Derive Google/GitHub OAuth callback URLs from API_BASE_URL by default, with explicit override env vars preserved
- Update env example/docs and add config tests for backend OAuth callback URL derivation

Refs #40 — narrow OAuth callback portability slice; broader env-driven URL cleanup remains open.

## Verification
- python3 -m compileall api core aura main.py
- python3 scripts/guard_no_public_secrets.py
- .venv/bin/python inline config assertions for API/frontend/OAuth callback URL helpers

Note: pytest is not installed in the local system or repo venv, so the new pytest test file could not be run directly here.