### PR TITLE
fix: derive WebSpawn surface links from configured URLs

### DIFF
--- a/api/routes/surfaces.py
+++ b/api/routes/surfaces.py
@@ -24,6 +24,7 @@ from api.middleware import get_current_user_id
 from api.tier_guard import get_user_tier
 from aura.agents.web_spawn_agent import WebSpawnAgent
 from aura.surface_registry import SurfaceRegistry
+from core.config import settings
 
 logger = logging.getLogger(__name__)
 
@@ -78,6 +79,24 @@ def _tier_gate(tier: str) -> None:
         )
 
 
+def _surface_listing_payload(surface: Dict[str, Any]) -> Dict[str, Any]:
+    """Build the public listing payload using configured app/API base URLs."""
+    spec = surface.get("spec", {})
+    surface_id = surface["id"]
+    return {
+        "id":           surface_id,
+        "title":        surface.get("title", ""),
+        "description":  spec.get("description", ""),
+        "inferred_type": surface.get("surface_type", "custom"),
+        "slug":         spec.get("slug", ""),
+        "url":          settings.surface_url(surface_id),
+        "api_endpoint": settings.surface_data_api_url(surface_id),
+        "status":       surface.get("status", "active"),
+        "view_count":   surface.get("view_count", 0),
+        "created_at":   surface.get("created_at", ""),
+    }
+
+
 # ─── Routes ───────────────────────────────────────────────────────────────────
 
 @router.post("/spawn")
@@ -126,21 +145,7 @@ async def get_my_surfaces(
     surfaces = await registry.get_user_surfaces(user_id)
 
     # Strip bulky generated source from listing (keep spec metadata only)
-    stripped = []
-    for s in surfaces:
-        spec = s.get("spec", {})
-        stripped.append({
-            "id":           s["id"],
-            "title":        s.get("title", ""),
-            "description":  spec.get("description", ""),
-            "inferred_type": s.get("surface_type", "custom"),
-            "slug":         spec.get("slug", ""),
-            "url":          f"https://avielcarlos.github.io/connectome-web/surfaces/{s['id']}",
-            "api_endpoint": f"https://connectome-api-production.up.railway.app/api/surfaces/{s['id']}/data",
-            "status":       s.get("status", "active"),
-            "view_count":   s.get("view_count", 0),
-            "created_at":   s.get("created_at", ""),
-        })
+    stripped = [_surface_listing_payload(s) for s in surfaces]
 
     return {"surfaces": stripped, "count": len(stripped)}
 

--- a/core/config.py
+++ b/core/config.py
@@ -152,6 +152,14 @@ class Settings(BaseSettings):
         """Build a frontend URL from the configured base without double slashes."""
         return self._join_base_url(self.FRONTEND_BASE_URL, path)
 
+    def surface_url(self, surface_id: str) -> str:
+        """Build the public frontend URL for a spawned surface."""
+        return self.frontend_url(f"/surfaces/{surface_id}")
+
+    def surface_data_api_url(self, surface_id: str) -> str:
+        """Build the public API URL for a spawned surface data endpoint."""
+        return self.api_url(f"/api/surfaces/{surface_id}/data")
+
     @property
     def github_redirect_uri(self) -> str:
         return (self.GITHUB_REDIRECT_URI or self.api_url("/api/auth/github/callback")).rstrip("?")

--- a/tests/test_frontend_urls.py
+++ b/tests/test_frontend_urls.py
@@ -17,6 +17,16 @@ def test_api_url_joins_paths_without_double_slashes():
     assert settings.api_url("api/screens/next") == "https://api.example.com/api/screens/next"
 
 
+def test_surface_urls_are_derived_from_configured_bases():
+    settings = Settings(
+        FRONTEND_BASE_URL="https://app.example/connectome/",
+        API_BASE_URL="https://api.example/",
+    )
+
+    assert settings.surface_url("surface_123") == "https://app.example/connectome/surfaces/surface_123"
+    assert settings.surface_data_api_url("surface_123") == "https://api.example/api/surfaces/surface_123/data"
+
+
 def test_oauth_frontend_callbacks_default_from_base_url():
     settings = Settings(FRONTEND_BASE_URL="https://app.example")
 


### PR DESCRIPTION
## Summary

Removes another hard-coded Railway/GitHub Pages URL pair from the WebSpawn surface listing path by deriving public surface links from configured backend/frontend base URLs.

## Changes

- Added `Settings.surface_url()` and `Settings.surface_data_api_url()` helpers.
- Updated `/api/surfaces/my` listing payloads to use configured `FRONTEND_BASE_URL` and `API_BASE_URL`.
- Added focused URL-helper coverage for trailing-slash-safe surface links.

## Testing

- `python3 -m compileall -q api core aura main.py`
- `PYTHONPATH=. uv run --with pytest --with pydantic-settings pytest tests/test_frontend_urls.py`
- `python3 scripts/guard_no_public_secrets.py`
- `git diff --check`

Part of #40.