### PR TITLE
chore: gate background workers by runtime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@
 # App / runtime
 APP_ENV=production
 LOG_LEVEL=INFO
+# Set false for API/web replicas; set true only on the dedicated worker/cron runtime.
+ENABLE_BACKGROUND_WORKERS=false
 API_BASE_URL=https://connectome-api-production.up.railway.app
 CONNECTOME_API_BASE=https://connectome-api-production.up.railway.app
 CONNECTOME_REPO_DIR=/app

--- a/aura/brain.py
+++ b/aura/brain.py
@@ -1741,8 +1741,13 @@ def get_brain() -> AuraBrain:
     return _brain
 
 
-async def init_brain():
-    """Call once on app startup."""
+async def init_brain(start_background_loops: bool = True):
+    """Call once on app startup.
+
+    Set ``start_background_loops`` to False for API/web runtimes that should
+    not own long-lived jobs. Dedicated worker/cron processes can leave it
+    enabled to run Aura's refresh and evaluation loops.
+    """
     global _brain
     _brain = AuraBrain()
     logger.info("Aura brain initialized")
@@ -1753,6 +1758,10 @@ async def init_brain():
     # Load dynamic agents from registry
     await _brain._load_dynamic_agents()
     logger.info(f"OraBrain: loaded {len(_brain._dynamic_agents)} dynamic agents from registry")
+
+    if not start_background_loops:
+        logger.info("Aura brain background loops disabled for this runtime")
+        return
 
     # Start WorldAgent background refresh loop
     asyncio.create_task(_brain.world.refresh_loop())

--- a/core/config.py
+++ b/core/config.py
@@ -62,6 +62,9 @@ class Settings(BaseSettings):
     # App
     APP_ENV: str = "development"
     LOG_LEVEL: str = "INFO"
+    # Set false for horizontally scaled API/web deployments. Dedicated worker
+    # processes can enable it to own long-lived schedulers and background loops.
+    ENABLE_BACKGROUND_WORKERS: bool = True
     API_BASE_URL: str = "https://connectome-api-production.up.railway.app"
     FRONTEND_BASE_URL: str = "https://avielcarlos.github.io/connectome-web"
     GOOGLE_FRONTEND_CALLBACK_URL: str = ""

--- a/docs/cloud-migration.md
+++ b/docs/cloud-migration.md
@@ -20,6 +20,7 @@ Run Connectome backend safely in Railway/cloud without depending on Avi's laptop
 - `/api/drive/*` routes use OAuth-backed `DriveAgentV2` instead of the local `gog` CLI.
 - WebSpawn Railway CLI deploy fallback is dev-only; production requires Railway API IDs.
 - `.env.example`, `render.yaml`, `deploy.sh`, and `requirements.txt` updated.
+- API/web runtime can disable long-lived schedulers with `ENABLE_BACKGROUND_WORKERS=false`; dedicated worker/cron runtimes should set it to `true`.
 
 ## Required production env vars before deploying this branch
 
@@ -33,6 +34,7 @@ Mandatory:
 - `GITHUB_WEBHOOK_SECRET`
 - `CONNECTOME_WORKER_JWT` or `ORA_JWT_TOKEN`
 - `FEEDBACK_SCREENSHOT_STORAGE_BACKEND=s3`
+- `ENABLE_BACKGROUND_WORKERS=false` for horizontally scaled API/web replicas. Use `true` only on the dedicated worker/cron runtime that should own notification, self-healing, backup, DAO, pricing, and Aura evaluation loops.
 - S3/R2 screenshot storage vars:
   - `FEEDBACK_SCREENSHOT_S3_BUCKET`
   - `FEEDBACK_SCREENSHOT_S3_ENDPOINT_URL`
@@ -110,6 +112,7 @@ Expected callback status is `422`, not `404`.
 ## Remaining non-blocking follow-up
 
 - Retire the legacy `DriveAgent` object from `AuraBrain` after discovery/search paths are fully verified against `DriveAgentV2`.
+- Add worker entrypoints/scheduler commands for the background loops gated by `ENABLE_BACKGROUND_WORKERS`.
 - Add cloud scheduler telemetry to replace local OpenClaw cron inspection.
 - Move OpenClaw Gateway to a Linux VPS/systemd host and keep the Mac as an optional node for macOS-only tools.
 - Consider making `/health` return non-200 when DB/Redis are degraded, or add a separate strict `/ready` endpoint for Railway.

--- a/main.py
+++ b/main.py
@@ -122,71 +122,78 @@ async def lifespan(app: FastAPI):
     await get_redis()
     logger.info("✅ Redis connected")
 
+    background_workers_enabled = settings.ENABLE_BACKGROUND_WORKERS
+
     # Initialize Aura brain
-    await init_brain()
+    await init_brain(start_background_loops=background_workers_enabled)
     logger.info("✅ Aura brain initialized")
 
-    # Start notification worker
-    start_notification_worker()
-    logger.info("✅ Notification worker started")
-
-    # Start SelfHealingAgent
-    self_healer = SelfHealingAgent()
-    app.state.self_healer = self_healer
     import asyncio
-    asyncio.create_task(self_healer.start_watching())
-    logger.info("✅ SelfHealingAgent watching")
-
-    # Start Aura daily self-check background task
-    asyncio.create_task(_daily_self_check_loop())
-    logger.info("✅ Aura daily self-check loop started")
-
-    # Start Aura brain backup freshness loops (hourly identity backup + monitor)
-    try:
-        from aura.agents.backup_freshness import start_backup_freshness_loops
-        start_backup_freshness_loops(app)
-    except Exception as _backup_e:
-        logger.warning(f"Aura backup freshness loops failed to start: {_backup_e}")
-
-    # Start ModelEvolutionAgent weekly loop
     from aura.brain import get_brain as _get_brain
     _aura_brain = _get_brain()
-    model_evolution_agent = ModelEvolutionAgent(_aura_brain._openai)
-    app.state.model_evolution = model_evolution_agent
-    asyncio.create_task(model_evolution_agent.start_weekly_check_loop())
-    logger.info("✅ ModelEvolutionAgent weekly loop started")
 
-    # Start DaoAgent background loops
-    from aura.agents.dao_agent import DaoAgent
-    dao_agent = DaoAgent(_aura_brain._openai)
-    app.state.dao_agent = dao_agent
-    asyncio.create_task(dao_agent.run_daily_evaluation_loop())
-    asyncio.create_task(dao_agent.run_weekly_leaderboard_loop())
-    asyncio.create_task(dao_agent.run_monthly_ltv_loop())
-    logger.info("✅ DaoAgent evaluation + leaderboard + LTV loops started")
+    if background_workers_enabled:
+        # Start notification worker
+        start_notification_worker()
+        logger.info("✅ Notification worker started")
 
-    # Start suggestion integration + CP award automation
-    asyncio.create_task(_suggestion_integration_loop())
-    logger.info("✅ Suggestion integration + CP award automation loop started")
+        # Start SelfHealingAgent
+        self_healer = SelfHealingAgent()
+        app.state.self_healer = self_healer
+        asyncio.create_task(self_healer.start_watching())
+        logger.info("✅ SelfHealingAgent watching")
+
+        # Start Aura daily self-check background task
+        asyncio.create_task(_daily_self_check_loop())
+        logger.info("✅ Aura daily self-check loop started")
+
+        # Start Aura brain backup freshness loops (hourly identity backup + monitor)
+        try:
+            from aura.agents.backup_freshness import start_backup_freshness_loops
+            start_backup_freshness_loops(app)
+        except Exception as _backup_e:
+            logger.warning(f"Aura backup freshness loops failed to start: {_backup_e}")
+
+        # Start ModelEvolutionAgent weekly loop
+        model_evolution_agent = ModelEvolutionAgent(_aura_brain._openai)
+        app.state.model_evolution = model_evolution_agent
+        asyncio.create_task(model_evolution_agent.start_weekly_check_loop())
+        logger.info("✅ ModelEvolutionAgent weekly loop started")
+
+        # Start DaoAgent background loops
+        from aura.agents.dao_agent import DaoAgent
+        dao_agent = DaoAgent(_aura_brain._openai)
+        app.state.dao_agent = dao_agent
+        asyncio.create_task(dao_agent.run_daily_evaluation_loop())
+        asyncio.create_task(dao_agent.run_weekly_leaderboard_loop())
+        asyncio.create_task(dao_agent.run_monthly_ltv_loop())
+        logger.info("✅ DaoAgent evaluation + leaderboard + LTV loops started")
+
+        # Start suggestion integration + CP award automation
+        asyncio.create_task(_suggestion_integration_loop())
+        logger.info("✅ Suggestion integration + CP award automation loop started")
+
+        # Start MetaAgent periodic self-improvement loop (every 6 hours)
+        from aura.agents.meta_agent import MetaAgent
+        meta_agent = MetaAgent(_aura_brain._openai)
+        app.state.meta_agent = meta_agent
+        asyncio.create_task(_meta_agent_loop(meta_agent))
+        logger.info("✅ MetaAgent self-improvement loop started")
+
+        # Initialize PricingAgent — Aura manages her own pricing
+        try:
+            from aura.agents.pricing_agent import get_pricing_agent
+            pricing_agent = get_pricing_agent(getattr(_aura_brain, '_openai', None))
+            app.state.pricing_agent = pricing_agent
+            asyncio.create_task(_pricing_agent_loop(pricing_agent))
+            logger.info("✅ PricingAgent initialized — Aura owns her monetization")
+        except Exception as _pe:
+            logging.warning(f"PricingAgent init failed (non-critical): {_pe}")
+    else:
+        logger.info("⏸️ Background workers disabled for API runtime")
+
     # Initialize EventDiscoveryAgent (lazy — syncs cities on demand)
     logger.info("✅ EventDiscoveryAgent ready (city syncs on demand)")
-
-    # Start MetaAgent periodic self-improvement loop (every 6 hours)
-    from aura.agents.meta_agent import MetaAgent
-    meta_agent = MetaAgent(_aura_brain._openai)
-    app.state.meta_agent = meta_agent
-    asyncio.create_task(_meta_agent_loop(meta_agent))
-    logger.info("✅ MetaAgent self-improvement loop started")
-
-    # Initialize PricingAgent — Aura manages her own pricing
-    try:
-        from aura.agents.pricing_agent import get_pricing_agent
-        pricing_agent = get_pricing_agent(getattr(_aura_brain, '_openai', None))
-        app.state.pricing_agent = pricing_agent
-        asyncio.create_task(_pricing_agent_loop(pricing_agent))
-    except Exception as _pe:
-        logging.warning(f"PricingAgent init failed (non-critical): {_pe}")
-    logger.info("✅ PricingAgent initialized — Aura owns her monetization")
 
     logger.info("🚀 Connectome is live")
     yield


### PR DESCRIPTION
## Summary

Adds an `ENABLE_BACKGROUND_WORKERS` runtime flag so horizontally scaled API/web replicas can boot without owning long-lived schedulers, while dedicated worker/cron runtimes can keep them enabled.

## Changes

- Adds `ENABLE_BACKGROUND_WORKERS` to backend settings and `.env.example`.
- Passes the flag into Aura brain startup to suppress brain refresh/evaluation loops on API runtimes.
- Gates notification, self-healing, backup freshness, model evolution, DAO, suggestion, meta, and pricing loops behind the same flag.
- Documents API-vs-worker runtime guidance in the cloud migration checklist.

## Testing

- `git diff --check`
- `python3 -m compileall -q core api aura main.py`
- `python3 scripts/guard_no_public_secrets.py`
- `python3 - <<'PY' ... Settings(ENABLE_BACKGROUND_WORKERS=False/True) ... PY`

Could not run pytest because `pytest` is not installed in this local Python environment.

Fixes AvielCarlos/connectome-backend#37