### PR TITLE
Fix suggestion integration pipeline schema backfill

### DIFF
--- a/api/routes/suggestions.py
+++ b/api/routes/suggestions.py
@@ -53,8 +53,10 @@ class SuggestionIntegrationUpdate(BaseModel):
 
 async def _ensure_suggestion_automation_schema() -> None:
     """Idempotent columns for app-feedback -> suggestion -> CP integration."""
+    await execute("ALTER TABLE user_suggestions ADD COLUMN IF NOT EXISTS title TEXT")
     await execute("ALTER TABLE user_suggestions ADD COLUMN IF NOT EXISTS content TEXT")
     await execute("ALTER TABLE user_suggestions ADD COLUMN IF NOT EXISTS body TEXT")
+    await execute("ALTER TABLE user_suggestions ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT NOW()")
     await execute("ALTER TABLE user_suggestions ADD COLUMN IF NOT EXISTS source TEXT DEFAULT 'manual'")
     await execute("ALTER TABLE user_suggestions ADD COLUMN IF NOT EXISTS source_id TEXT")
     await execute("ALTER TABLE user_suggestions ADD COLUMN IF NOT EXISTS integration_status TEXT DEFAULT 'pending'")
@@ -62,6 +64,8 @@ async def _ensure_suggestion_automation_schema() -> None:
     await execute("ALTER TABLE user_suggestions ADD COLUMN IF NOT EXISTS triage_metadata JSONB DEFAULT '{}'::jsonb")
     await execute("ALTER TABLE user_suggestions ADD COLUMN IF NOT EXISTS adopted_cp_awarded INTEGER DEFAULT 0")
     await execute("ALTER TABLE user_suggestions ADD COLUMN IF NOT EXISTS adopted_at TIMESTAMPTZ")
+    await execute("UPDATE user_suggestions SET title = COALESCE(title, content, body, 'Suggestion') WHERE title IS NULL")
+    await execute("UPDATE user_suggestions SET updated_at = COALESCE(updated_at, created_at, NOW()) WHERE updated_at IS NULL")
     await execute("CREATE INDEX IF NOT EXISTS idx_user_suggestions_integration_status ON user_suggestions(integration_status)")
     await execute(
         """

--- a/core/database.py
+++ b/core/database.py
@@ -1202,7 +1202,16 @@ async def run_migrations():
         """)
         # Idempotent migrations for existing user_suggestions table
         await conn.execute("""
+            ALTER TABLE user_suggestions ADD COLUMN IF NOT EXISTS title TEXT
+        """)
+        await conn.execute("""
             ALTER TABLE user_suggestions ADD COLUMN IF NOT EXISTS content TEXT
+        """)
+        await conn.execute("""
+            ALTER TABLE user_suggestions ADD COLUMN IF NOT EXISTS body TEXT
+        """)
+        await conn.execute("""
+            ALTER TABLE user_suggestions ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT NOW()
         """)
         await conn.execute("""
             ALTER TABLE user_suggestions ADD COLUMN IF NOT EXISTS cp_earned INTEGER DEFAULT 10
@@ -1217,6 +1226,8 @@ async def run_migrations():
         await conn.execute("ALTER TABLE user_suggestions ADD COLUMN IF NOT EXISTS triage_metadata JSONB DEFAULT '{}'::jsonb")
         await conn.execute("ALTER TABLE user_suggestions ADD COLUMN IF NOT EXISTS adopted_cp_awarded INTEGER DEFAULT 0")
         await conn.execute("ALTER TABLE user_suggestions ADD COLUMN IF NOT EXISTS adopted_at TIMESTAMPTZ")
+        await conn.execute("UPDATE user_suggestions SET title = COALESCE(title, content, body, 'Suggestion') WHERE title IS NULL")
+        await conn.execute("UPDATE user_suggestions SET updated_at = COALESCE(updated_at, created_at, NOW()) WHERE updated_at IS NULL")
         await conn.execute("""
             CREATE INDEX IF NOT EXISTS idx_user_suggestions_integration_status
             ON user_suggestions(integration_status)

--- a/migrations/011_suggestion_integration_cp.sql
+++ b/migrations/011_suggestion_integration_cp.sql
@@ -1,8 +1,10 @@
 -- Suggestion integration + CP award automation
 -- Links app feedback to actionable suggestions and records adoption/implementation CP.
 
+ALTER TABLE user_suggestions ADD COLUMN IF NOT EXISTS title TEXT;
 ALTER TABLE user_suggestions ADD COLUMN IF NOT EXISTS content TEXT;
 ALTER TABLE user_suggestions ADD COLUMN IF NOT EXISTS body TEXT;
+ALTER TABLE user_suggestions ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT NOW();
 ALTER TABLE user_suggestions ADD COLUMN IF NOT EXISTS source TEXT DEFAULT 'manual';
 ALTER TABLE user_suggestions ADD COLUMN IF NOT EXISTS source_id TEXT;
 ALTER TABLE user_suggestions ADD COLUMN IF NOT EXISTS integration_status TEXT DEFAULT 'pending';
@@ -10,6 +12,14 @@ ALTER TABLE user_suggestions ADD COLUMN IF NOT EXISTS integration_reference TEXT
 ALTER TABLE user_suggestions ADD COLUMN IF NOT EXISTS triage_metadata JSONB DEFAULT '{}'::jsonb;
 ALTER TABLE user_suggestions ADD COLUMN IF NOT EXISTS adopted_cp_awarded INTEGER DEFAULT 0;
 ALTER TABLE user_suggestions ADD COLUMN IF NOT EXISTS adopted_at TIMESTAMPTZ;
+
+UPDATE user_suggestions
+SET title = COALESCE(title, content, body, 'Suggestion')
+WHERE title IS NULL;
+
+UPDATE user_suggestions
+SET updated_at = COALESCE(updated_at, created_at, NOW())
+WHERE updated_at IS NULL;
 
 CREATE INDEX IF NOT EXISTS idx_user_suggestions_integration_status
     ON user_suggestions(integration_status);


### PR DESCRIPTION
## Summary
- Adds missing legacy-safe `title` and `updated_at` columns to suggestion automation migrations.
- Backfills `title` / `updated_at` for existing suggestion rows so automation queries no longer fail on production-shaped tables.
- Keeps app feedback import and integration/CP automation idempotent.

## Production action already completed
- Added the missing production columns/indexes.
- Imported 26 app feedback notes into `user_suggestions`.
- Queued 26 low-risk app-feedback suggestions for integration triage.
- Remaining pending suggestions: 7 old manual rows.

## Validation
- `python3 -m py_compile api/routes/suggestions.py core/database.py aura/agents/reporter_agent.py`
- `python3 scripts/guard_no_public_secrets.py`
- Production DB verification: `has_title=true`, `has_updated_at=true`, `app_imported=26`, `unimported_app_feedback=0`, `accepted/queued=26`, `pending=7`